### PR TITLE
Call logging.basicConfig only within main

### DIFF
--- a/ubipop/cli.py
+++ b/ubipop/cli.py
@@ -5,7 +5,7 @@ import logging
 
 DEFAULT_LOG_FMT = "%(asctime)s [%(levelname)-8s] %(message)s"
 DEFAULT_DATE_FMT = "%Y-%m-%d %H:%M:%S %z"
-logging.basicConfig(format=DEFAULT_LOG_FMT, datefmt=DEFAULT_DATE_FMT)
+
 _LOG = logging.getLogger("ubipop")
 _LOG.setLevel(logging.DEBUG)
 
@@ -51,6 +51,8 @@ def parse_args(args):
 
 
 def main(args):
+    logging.basicConfig(format=DEFAULT_LOG_FMT, datefmt=DEFAULT_DATE_FMT)
+
     opts, auth = parse_args(args)
 
     ubipop.UbiPopulate(opts.pulp_hostname, auth, opts.dry_run, opts.input,


### PR DESCRIPTION
Merely importing a module shouldn't have the side-effect of changing
the global logging config, which can only be done once per process.
It's fragile and could lead to confusing behavior where log format
differs depending on the order of imports.

Since this is only intended to enable output for the CLI, let's
move it within the CLI's main method.