### PR TITLE
Remove public API for now

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,32 +3,7 @@
 [![Coverage Status](https://coveralls.io/repos/github/release-engineering/ubi-population-tool/badge.svg?branch=master)](https://coveralls.io/github/release-engineering/ubi-population-tool?branch=master)
 
 
-A python library and cli for populating ubi repositories.
-
-The library provides convenient means how to populate ubi repositories: 
-- consumes ubi config using *ubi-config* tool
-- calculates expected content of ubi repositories
-- determines pulp actions which will ensure expected content to be in ubi repos
-
-# Library usage
-Example of typical usage of library follows:
-
- 
-```python
-from ubipop import UbiPopulate
-
-ubi = UbiPopulate(content_sets, pulp_url, ("user", "pass"), dry_run=False)
-ubi.populate_ubi_repos()
-```
-
-Required arguments are:
-- **content_sets**: list of content sets that will be used for reading config
-- **pulp_url**: url of pulp_server
-- **tuple** of username nad password of pulp server
-- **dry_run**: boolean, if True, it calculates and prints expected pulp actions, if False execute pulp actions
-
-By calling *populate_ubi_repos()* whole process of calculation of desired content of
-ubi repos and required action is started.
+A command-line tool for populating ubi repositories.
 
 # Cli usage
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,7 +1,7 @@
 ubi-population-tool
 ===================
 
-A python library and cli for populating ubi repositories.
+A command-line tool for populating UBI repositories.
 
 .. contents::
   :local:
@@ -23,21 +23,3 @@ Then run ``ubipop`` command against a Pulp server, e.g.
       --pulp-hostname mypulp.example.com \
       --user admin --password admin \
       --conf-src https://mygit.example.com/ubi/config
-
-Or import & use classes from ``ubipop`` module:
-
-.. code-block:: python
-
-    from ubipop import UbiPopulateRunner
-
-    UbiPopulateRunner(...).run_ubi_population()
-
-
-API Reference
--------------
-
-.. autoclass:: ubipop.UbiPopulate
-    :members:
-
-.. autoclass:: ubipop.UbiPopulateRunner
-    :members:

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 
 def get_description():
-    return 'Ubi population library for populating ubi repositories'
+    return 'Tool for populating ubi repositories'
 
 
 def get_long_description():


### PR DESCRIPTION
The API is too unstable at the moment and likely needs some
significant revision before we could commit to supporting that.
Let's rebrand this project as only a CLI tool for now, until we
have time to revise the API (probably meaning until we're ready
to actually *use* the API from outside of the tool).

Fixes #9