### PR TITLE
Refactor associations and unassociations, add test coverage, renamed some attributes

### DIFF
--- a/tests/test_ubipop.py
+++ b/tests/test_ubipop.py
@@ -401,10 +401,10 @@ def test_get_pulp_actions_no_actions(mock_ubipop_runner, mock_current_content_ft
 
 @pytest.fixture()
 def set_logging():
-    _LOG = logging.getLogger("ubipop")
-    _LOG.setLevel(logging.DEBUG)
-    yield _LOG
-    _LOG.handlers = []
+    logger = logging.getLogger("ubipop")
+    logger.setLevel(logging.DEBUG)
+    yield logger
+    logger.handlers = []
 
 
 def test_log_pulp_action(capsys, set_logging, mock_ubipop_runner):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,57 @@
+import pytest
+from ubipop._utils import (PulpAction, AssociateAction, AssociateActionModules,
+                           AssociateActionRpms, UnassociateActionRpms,
+                           UnassociateActionModules)
+from ubipop._pulp_client import Repo
+from mock import MagicMock
+
+
+def test_raise_not_implemented_pulp_action():
+    units = ["unit1", "unit2"]
+    repo = Repo("test", "1", "2", None)
+    action = PulpAction(units, repo)
+    pytest.raises(NotImplementedError, action.get_action, None)
+
+
+def test_raise_not_implemented_associate_action():
+    units = ["unit1", "unit2"]
+    repo = Repo("test", "1", "2", None)
+    src_repo = Repo("test", "1", "2", None)
+    action = AssociateAction(units, repo, src_repo)
+    pytest.raises(NotImplementedError, action.get_action, None)
+
+
+@pytest.mark.parametrize("klass, method",
+                         [(AssociateActionModules, "associate_modules"),
+                          (AssociateActionRpms, "associate_packages")]
+                         )
+def test_get_action_associate(klass, method):
+    units = ["unit1", "unit2"]
+    dst_repo = Repo("test_dst", "1", "2", None)
+    src_repo = Repo("test_src", "1", "2", None)
+    action = klass(units, dst_repo, src_repo)
+    associate_action, current_units, src_repo_id, dst_repo_id = action.get_action(MagicMock())
+
+    assert "mock." + method in str(associate_action)
+    assert current_units == units
+    assert dst_repo_id == dst_repo.repo_id
+    assert src_repo_id == src_repo.repo_id
+
+
+@pytest.mark.parametrize("klass, method",
+                         [(UnassociateActionModules, "unassociate_modules"),
+                          (UnassociateActionRpms, "unassociate_packages")]
+                         )
+def test_get_action_unassociate(klass, method):
+    units = ["unit1", "unit2"]
+    dst_repo = Repo("test_dst", "1", "2", None)
+    action = klass(units, dst_repo)
+    associate_action, current_units, dst_repo_id = action.get_action(MagicMock())
+
+    assert "mock." + method in str(associate_action)
+    assert current_units == units
+    assert dst_repo_id == dst_repo.repo_id
+
+
+
+

--- a/ubipop/__init__.py
+++ b/ubipop/__init__.py
@@ -359,8 +359,7 @@ class UbiPopulateRunner(object):
             self.log_pulp_actions(associations, unassociations)
         else:
             fts = []
-            fts.extend(self._associate_units(associations))
-            fts.extend(self._unassociate_units(unassociations))
+            fts.extend(self._associate_unassociate_units(associations + unassociations))
             # wait for associate/unassociate tasks
             for ft in as_completed(fts):
                 tasks = ft.result()
@@ -373,19 +372,12 @@ class UbiPopulateRunner(object):
 
         return self._changed_repos
 
-    def _associate_units(self, associate_action_list):
+    def _associate_unassociate_units(self, action_list):
         fts = []
-        for action in associate_action_list:
+        for action in action_list:
             if action.units:
-                self._changed_repos.add(action.repo.repo_id)
-                fts.append(self._executor.submit(action.get_action(self.pulp)))
-
-        return fts
-
-    def _unassociate_units(self, unassociate_action_list):
-        fts = []
-        for action in unassociate_action_list:
-            fts.append(self._executor.submit(action.get_action(self.pulp)))
+                self._changed_repos.add(action.dst_repo.repo_id)
+                fts.append(self._executor.submit(*action.get_action(self.pulp)))
 
         return fts
 

--- a/ubipop/__init__.py
+++ b/ubipop/__init__.py
@@ -235,7 +235,7 @@ class UbiPopulateRunner(object):
             self.keep_n_latest_modules(modules)
 
     def _finalize_rpms_output_set(self):
-        for _, packages in self.out_repo_set.packages.items():
+        for _, packages in self.repos.packages.items():
             self.sort_packages(packages)
             self.keep_n_newest_packages(packages)  # with respect to packages referenced by modules
 

--- a/ubipop/__init__.py
+++ b/ubipop/__init__.py
@@ -279,10 +279,10 @@ class UbiPopulateRunner(object):
         to_unassociate = diff_f(current, expected)
         return to_associate, to_unassociate
 
-    def _gets_action_for_mds(self, modules, current):
+    def _get_pulp_actions_mds(self, modules, current):
         return self._determine_pulp_actions(modules, current, self._diff_modules_by_nsvca)
 
-    def _get_actions_pkgs(self, pkgs, current):
+    def _get_pulp_actions_pkgs(self, pkgs, current):
         return self._determine_pulp_actions(pkgs, current, self._diff_packages_by_filename)
 
     def _get_pulp_actions(self, current_modules_ft, current_rpms_ft, current_srpms_ft,
@@ -295,18 +295,18 @@ class UbiPopulateRunner(object):
         Content that needs unassociation: unit is in current but not in expected
         No action: unit is in current and in expected
         """
-        modules_assoc, modules_unassoc = self._gets_action_for_mds(self.repos.modules,
-                                                                   current_modules_ft.result())
-        rpms_assoc, rpms_unassoc = self._get_actions_pkgs(self.repos.packages,
-                                                          current_rpms_ft.result())
-        srpms_assoc, srpms_unassoc = self._get_actions_pkgs(self.repos.source_rpms,
-                                                            current_srpms_ft.result())
+        modules_assoc, modules_unassoc = self._get_pulp_actions_mds(self.repos.modules,
+                                                                    current_modules_ft.result())
+        rpms_assoc, rpms_unassoc = self._get_pulp_actions_pkgs(self.repos.packages,
+                                                               current_rpms_ft.result())
+        srpms_assoc, srpms_unassoc = self._get_pulp_actions_pkgs(self.repos.source_rpms,
+                                                                 current_srpms_ft.result())
 
         debug_assoc = None
         debug_unassoc = None
         if current_debug_rpms_ft is not None:
-            debug_assoc, debug_unassoc = self._get_actions_pkgs(self.repos.debug_rpms,
-                                                                current_debug_rpms_ft.result())
+            debug_assoc, debug_unassoc = self._get_pulp_actions_pkgs(self.repos.debug_rpms,
+                                                                     current_debug_rpms_ft.result())
 
         associations = (AssociateActionModules(modules_assoc, self.repos.in_repos.rpm,
                                                self.repos.out_repos.rpm),

--- a/ubipop/__init__.py
+++ b/ubipop/__init__.py
@@ -422,7 +422,7 @@ class UbiPopulateRunner(object):
         for item in unassociations:
             if item.units:
                 for unit in item.units:
-                    _LOG.info("Would unassociate %s from %s", unit.filename, item.dst_repo.repo_id)
+                    _LOG.info("Would unassociate %s from %s", unit, item.dst_repo.repo_id)
             else:
                 _LOG.info("No unassociation expected for %s from %s", item.TYPE,
                           item.dst_repo.repo_id)

--- a/ubipop/_utils.py
+++ b/ubipop/_utils.py
@@ -36,7 +36,7 @@ class PulpAction(object):
         self.dst_repo = dst_repo
 
     def get_action(self, *args):
-        raise NotImplemented
+        raise NotImplementedError
 
 
 class AssociateAction(PulpAction):

--- a/ubipop/_utils.py
+++ b/ubipop/_utils.py
@@ -28,3 +28,48 @@ def splitFilename(filename):
 
     name = filename[epochIndex + 1:verIndex]
     return name, ver, rel, epoch, arch
+
+
+class PulpAction(object):
+    def __init__(self, units,  dst_repo):
+        self.units = units
+        self.dst_repo = dst_repo
+
+    def get_action(self, *args):
+        raise NotImplemented
+
+
+class AssociateAction(PulpAction):
+    def __init__(self, units, dst_repo, src_repo):
+        super(AssociateAction, self).__init__(units, dst_repo)
+        self.src_repo = src_repo
+
+
+class AssociateActionModules(AssociateAction):
+    TYPE = "modules"
+
+    def get_action(self, pulp_client_inst):
+        return pulp_client_inst.associate_modules, self.units, self.src_repo.repo_id, \
+               self.dst_repo.repo_id
+
+
+class UnassociateActionModules(PulpAction):
+    TYPE = "modules"
+
+    def get_action(self, pulp_client_inst):
+        return pulp_client_inst.unassociate_modules, self.units, self.dst_repo.repo_id
+
+
+class AssociateActionRpms(AssociateAction):
+    TYPE = "packages"
+
+    def get_action(self, pulp_client_inst):
+        return pulp_client_inst.associate_packages, self.units, self.src_repo.repo_id, \
+               self.dst_repo.repo_id
+
+
+class UnassociateActionRpms(PulpAction):
+    TYPE = "packages"
+
+    def get_action(self, pulp_client_inst):
+        return pulp_client_inst.unassociate_packages, self.units, self.dst_repo.repo_id

--- a/ubipop/_utils.py
+++ b/ubipop/_utils.py
@@ -35,7 +35,7 @@ class PulpAction(object):
         self.units = units
         self.dst_repo = dst_repo
 
-    def get_action(self, *args):
+    def get_action(self, pulp_client_inst):
         raise NotImplementedError
 
 
@@ -43,6 +43,9 @@ class AssociateAction(PulpAction):
     def __init__(self, units, dst_repo, src_repo):
         super(AssociateAction, self).__init__(units, dst_repo)
         self.src_repo = src_repo
+
+    def get_action(self, pulp_client_inst):
+        raise NotImplementedError
 
 
 class AssociateActionModules(AssociateAction):


### PR DESCRIPTION
This PR is a refactor of creation of units that should associated and unassociated where I added more abstraction which should result better readability and maintainability. 
Renamed **out_repo_set** attr to **repos**, of UbiPopulateRunner class. I found it too long.

Also added tests to improve code coverage.