### PR TITLE
Add option to write all output repos to file

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -56,7 +56,7 @@ def test_default_config_source(mock_ubipopulate):
     args = ['--pulp-hostname', 'foo.pulp.com', '--user', 'foo', '--pass', 'foo']
     main(args)
     mock_ubipopulate.assert_called_once_with('foo.pulp.com', ('foo', 'foo'), False, [], None,
-                                             False, 4, None)
+                                             False, 4, None, False)
 
 
 @mock.patch('ubipop.UbiPopulate')
@@ -65,7 +65,7 @@ def test_custom_config_source(mock_ubipopulate):
             'custom/conf/dir']
     main(args)
     mock_ubipopulate.assert_called_once_with('foo.pulp.com', ('foo', 'foo'), False, [],
-                                             'custom/conf/dir', False, 4, None)
+                                             'custom/conf/dir', False, 4, None, False)
 
 
 @mock.patch('ubipop.UbiPopulate')
@@ -74,7 +74,7 @@ def test_crt(mock_ubipopulate):
             'custom/conf/dir']
     main(args)
     mock_ubipopulate.assert_called_once_with('foo.pulp.com', ('/cert.cert', ), False, [],
-                                             'custom/conf/dir', False, 4, None)
+                                             'custom/conf/dir', False, 4, None, False)
 
 
 @mock.patch('ubipop.UbiPopulate')
@@ -83,7 +83,7 @@ def test_specified_filenames(mock_ubipopulate):
             'custom/conf/dir', 'f1', 'f2']
     main(args)
     mock_ubipopulate.assert_called_once_with('foo.pulp.com', ('foo', 'foo'), False, ['f1', 'f2'],
-                                             'custom/conf/dir', False, 4, None)
+                                             'custom/conf/dir', False, 4, None, False)
 
 
 @mock.patch('ubipop.UbiPopulate')
@@ -92,7 +92,7 @@ def test_dry_run(mock_ubipopulate):
             'custom/conf/dir', 'f1', 'f2', '--dry-run']
     main(args)
     mock_ubipopulate.assert_called_once_with('foo.pulp.com', ('foo', 'foo'), True, ['f1', 'f2'],
-                                             'custom/conf/dir', False, 4, None)
+                                             'custom/conf/dir', False, 4, None, False)
 
 
 @mock.patch('ubipop.UbiPopulate')
@@ -101,7 +101,7 @@ def test_custom_workers_number(mock_ubipopulate):
             'custom/conf/dir', 'f1', 'f2', '--workers', '42']
     main(args)
     mock_ubipopulate.assert_called_once_with('foo.pulp.com', ('foo', 'foo'), False, ['f1', 'f2'],
-                                             'custom/conf/dir', False, 42, None)
+                                             'custom/conf/dir', False, 42, None, False)
 
 
 @mock.patch('ubipop.UbiPopulate')
@@ -110,7 +110,7 @@ def test_insecure(mock_ubipopulate):
             'custom/conf/dir', 'f1', 'f2', '--workers', '42', '--insecure']
     main(args)
     mock_ubipopulate.assert_called_once_with('foo.pulp.com', ('foo', 'foo'), False, ['f1', 'f2'],
-                                             'custom/conf/dir', True, 42, None)
+                                             'custom/conf/dir', True, 42, None, False)
 
 
 @mock.patch('ubipop.UbiPopulate')
@@ -119,4 +119,13 @@ def test_output_file(mock_ubipopulate):
             '--output-changed-repos', '/foo/out/repos.txt']
     main(args)
     mock_ubipopulate.assert_called_once_with('foo.pulp.com', ('foo', 'foo'), False, [], None,
-                                             False, 4, '/foo/out/repos.txt')
+                                             False, 4, '/foo/out/repos.txt', False)
+
+
+@mock.patch('ubipop.UbiPopulate')
+def test_output_file(mock_ubipopulate):
+    args = ['--pulp-hostname', 'foo.pulp.com', '--user', 'foo', '--pass', 'foo',
+            '--output-changed-repos', '/foo/out/repos.txt', '--output-all-repos']
+    main(args)
+    mock_ubipopulate.assert_called_once_with('foo.pulp.com', ('foo', 'foo'), False, [], None,
+                                             False, 4, '/foo/out/repos.txt', True)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -56,7 +56,7 @@ def test_default_config_source(mock_ubipopulate):
     args = ['--pulp-hostname', 'foo.pulp.com', '--user', 'foo', '--pass', 'foo']
     main(args)
     mock_ubipopulate.assert_called_once_with('foo.pulp.com', ('foo', 'foo'), False, [], None,
-                                             False, 4, None, False)
+                                             False, 4, None)
 
 
 @mock.patch('ubipop.UbiPopulate')
@@ -65,7 +65,7 @@ def test_custom_config_source(mock_ubipopulate):
             'custom/conf/dir']
     main(args)
     mock_ubipopulate.assert_called_once_with('foo.pulp.com', ('foo', 'foo'), False, [],
-                                             'custom/conf/dir', False, 4, None, False)
+                                             'custom/conf/dir', False, 4, None)
 
 
 @mock.patch('ubipop.UbiPopulate')
@@ -74,7 +74,7 @@ def test_crt(mock_ubipopulate):
             'custom/conf/dir']
     main(args)
     mock_ubipopulate.assert_called_once_with('foo.pulp.com', ('/cert.cert', ), False, [],
-                                             'custom/conf/dir', False, 4, None, False)
+                                             'custom/conf/dir', False, 4, None)
 
 
 @mock.patch('ubipop.UbiPopulate')
@@ -83,7 +83,7 @@ def test_specified_filenames(mock_ubipopulate):
             'custom/conf/dir', 'f1', 'f2']
     main(args)
     mock_ubipopulate.assert_called_once_with('foo.pulp.com', ('foo', 'foo'), False, ['f1', 'f2'],
-                                             'custom/conf/dir', False, 4, None, False)
+                                             'custom/conf/dir', False, 4, None)
 
 
 @mock.patch('ubipop.UbiPopulate')
@@ -92,7 +92,7 @@ def test_dry_run(mock_ubipopulate):
             'custom/conf/dir', 'f1', 'f2', '--dry-run']
     main(args)
     mock_ubipopulate.assert_called_once_with('foo.pulp.com', ('foo', 'foo'), True, ['f1', 'f2'],
-                                             'custom/conf/dir', False, 4, None, False)
+                                             'custom/conf/dir', False, 4, None)
 
 
 @mock.patch('ubipop.UbiPopulate')
@@ -101,7 +101,7 @@ def test_custom_workers_number(mock_ubipopulate):
             'custom/conf/dir', 'f1', 'f2', '--workers', '42']
     main(args)
     mock_ubipopulate.assert_called_once_with('foo.pulp.com', ('foo', 'foo'), False, ['f1', 'f2'],
-                                             'custom/conf/dir', False, 42, None, False)
+                                             'custom/conf/dir', False, 42, None)
 
 
 @mock.patch('ubipop.UbiPopulate')
@@ -110,22 +110,14 @@ def test_insecure(mock_ubipopulate):
             'custom/conf/dir', 'f1', 'f2', '--workers', '42', '--insecure']
     main(args)
     mock_ubipopulate.assert_called_once_with('foo.pulp.com', ('foo', 'foo'), False, ['f1', 'f2'],
-                                             'custom/conf/dir', True, 42, None, False)
+                                             'custom/conf/dir', True, 42, None)
 
 
 @mock.patch('ubipop.UbiPopulate')
 def test_output_file(mock_ubipopulate):
     args = ['--pulp-hostname', 'foo.pulp.com', '--user', 'foo', '--pass', 'foo',
-            '--output-changed-repos', '/foo/out/repos.txt']
+            '--output-repos', '/foo/out/repos.txt']
     main(args)
     mock_ubipopulate.assert_called_once_with('foo.pulp.com', ('foo', 'foo'), False, [], None,
-                                             False, 4, '/foo/out/repos.txt', False)
+                                             False, 4, '/foo/out/repos.txt')
 
-
-@mock.patch('ubipop.UbiPopulate')
-def test_output_file(mock_ubipopulate):
-    args = ['--pulp-hostname', 'foo.pulp.com', '--user', 'foo', '--pass', 'foo',
-            '--output-changed-repos', '/foo/out/repos.txt', '--output-all-repos']
-    main(args)
-    mock_ubipopulate.assert_called_once_with('foo.pulp.com', ('foo', 'foo'), False, [], None,
-                                             False, 4, '/foo/out/repos.txt', True)

--- a/tests/test_ubipop.py
+++ b/tests/test_ubipop.py
@@ -17,9 +17,22 @@ TEST_DATA_DIR = os.path.join(os.path.dirname(__file__), './data')
 
 @pytest.fixture()
 def ubi_repo_set():
-    rhel_repo_set = RepoSet("foo-rpms", "foo-source", "foo-debug")
-    ubi_repo_set = RepoSet("ubi-foo-rpms", "ubi-foo-source", "ubi-foo-debug")
-    yield UbiRepoSet(rhel_repo_set, ubi_repo_set)
+    yield UbiRepoSet(RepoSet(get_test_repo(repo_id="foo-rpms"),
+                             get_test_repo(repo_id="foo-source"),
+                             get_test_repo(repo_id="foo-debug")),
+                     RepoSet(get_test_repo(repo_id="ubi-foo-rpms"),
+                             get_test_repo(repo_id="ubi-foo-source"),
+                             get_test_repo(repo_id="ubi-foo-debug")))
+
+
+@pytest.fixture()
+def ubi_repo_set_no_debug():
+    yield UbiRepoSet(RepoSet(get_test_repo(repo_id="foo-rpms"),
+                             get_test_repo(repo_id="foo-source"),
+                             None),
+                     RepoSet(get_test_repo(repo_id="ubi-foo-rpms"),
+                             get_test_repo(repo_id="ubi-foo-source"),
+                             None))
 
 
 @pytest.fixture()
@@ -54,6 +67,18 @@ def get_test_mod(**kwargs):
                   kwargs.get('arch', ''),
                   kwargs.get('packages', ''),
                   kwargs.get('profiles', ''))
+
+
+def test_get_output_repo_ids(ubi_repo_set):
+    repo_ids = ubi_repo_set.get_output_repo_ids()
+    assert len(repo_ids) == 3
+    assert repo_ids == set(["ubi-foo-rpms", "ubi-foo-source", "ubi-foo-debug"])
+
+
+def test_get_output_repo_ids_no_debug(ubi_repo_set_no_debug):
+    repo_ids = ubi_repo_set_no_debug.get_output_repo_ids()
+    assert len(repo_ids) == 2
+    assert repo_ids == set(["ubi-foo-rpms", "ubi-foo-source"])
 
 
 def test_get_packages_from_module(mock_ubipop_runner):
@@ -285,16 +310,16 @@ def test_create_debug_output_set(mock_ubipop_runner):
 
 
 @pytest.fixture()
-def mock_get_repo_pairs():
+def mock_get_repo_pairs(ubi_repo_set):
     with patch('ubipop.UbiPopulate._get_input_and_output_repo_pairs') as get_repo_pairs:
         get_repo_pairs.return_value = [ubi_repo_set]
         yield get_repo_pairs
 
 
 @pytest.fixture()
-def mock_run_ubi_population(ubi_repo_set):
+def mock_run_ubi_population():
     with patch('ubipop.UbiPopulateRunner.run_ubi_population') as run_ubi_population:
-        run_ubi_population.return_value = set(['repo1', 'repo2'])
+        run_ubi_population.return_value = set(['changed_repo_id_1', 'changed_repo_id_2'])
         yield run_ubi_population
 
 
@@ -312,8 +337,27 @@ def test_create_output_file(mock_ubipop_runner, mock_get_repo_pairs, mocked_ubic
             content = f.readlines()
 
         assert len(content) == 2
-        assert sorted(content) == ['repo1\n', 'repo2\n']
+        assert sorted(content) == ['changed_repo_id_1\n', 'changed_repo_id_2\n']
 
+    finally:
+        shutil.rmtree(path)
+
+
+def test_create_output_file_all_repos(mock_ubipop_runner, mock_get_repo_pairs,
+                                      mocked_ubiconfig_load_all, mock_run_ubi_population):
+    path = tempfile.mkdtemp("ubipop")
+    try:
+        out_file_path = os.path.join(path, 'output.txt')
+        ubipop = UbiPopulate("foo.pulp.com", ('foo', 'foo'), False,
+                             output_changed_repos=out_file_path, output_all_repos=True)
+
+        ubipop.populate_ubi_repos()
+
+        with open(out_file_path) as f:
+            content = f.readlines()
+
+        assert len(content) == 3
+        assert sorted(content) == sorted(["ubi-foo-rpms\n", "ubi-foo-source\n", "ubi-foo-debug\n"])
     finally:
         shutil.rmtree(path)
 

--- a/tests/test_ubipop.py
+++ b/tests/test_ubipop.py
@@ -71,13 +71,11 @@ def get_test_mod(**kwargs):
 
 def test_get_output_repo_ids(ubi_repo_set):
     repo_ids = ubi_repo_set.get_output_repo_ids()
-    assert len(repo_ids) == 3
     assert repo_ids == set(["ubi-foo-rpms", "ubi-foo-source", "ubi-foo-debug"])
 
 
 def test_get_output_repo_ids_no_debug(ubi_repo_set_no_debug):
     repo_ids = ubi_repo_set_no_debug.get_output_repo_ids()
-    assert len(repo_ids) == 2
     assert repo_ids == set(["ubi-foo-rpms", "ubi-foo-source"])
 
 
@@ -319,28 +317,7 @@ def mock_get_repo_pairs(ubi_repo_set):
 @pytest.fixture()
 def mock_run_ubi_population():
     with patch('ubipop.UbiPopulateRunner.run_ubi_population') as run_ubi_population:
-        run_ubi_population.return_value = set(['changed_repo_id_1', 'changed_repo_id_2'])
         yield run_ubi_population
-
-
-def test_create_output_file(mock_ubipop_runner, mock_get_repo_pairs, mocked_ubiconfig_load_all,
-                            mock_run_ubi_population):
-    path = tempfile.mkdtemp("ubipop")
-    try:
-        out_file_path = os.path.join(path, 'output.txt')
-        ubipop = UbiPopulate("foo.pulp.com", ('foo', 'foo'), False,
-                             output_changed_repos=out_file_path)
-
-        ubipop.populate_ubi_repos()
-
-        with open(out_file_path) as f:
-            content = f.readlines()
-
-        assert len(content) == 2
-        assert sorted(content) == ['changed_repo_id_1\n', 'changed_repo_id_2\n']
-
-    finally:
-        shutil.rmtree(path)
 
 
 def test_create_output_file_all_repos(mock_ubipop_runner, mock_get_repo_pairs,
@@ -349,14 +326,13 @@ def test_create_output_file_all_repos(mock_ubipop_runner, mock_get_repo_pairs,
     try:
         out_file_path = os.path.join(path, 'output.txt')
         ubipop = UbiPopulate("foo.pulp.com", ('foo', 'foo'), False,
-                             output_changed_repos=out_file_path, output_all_repos=True)
+                             output_repos=out_file_path)
 
         ubipop.populate_ubi_repos()
 
         with open(out_file_path) as f:
             content = f.readlines()
 
-        assert len(content) == 3
         assert sorted(content) == sorted(["ubi-foo-rpms\n", "ubi-foo-source\n", "ubi-foo-debug\n"])
     finally:
         shutil.rmtree(path)
@@ -493,4 +469,3 @@ def test_associate_units(mock_ubipop_runner):
 
     assert len(ret) == 1
     assert ret[0].result() == ["task_id"]
-    assert mock_ubipop_runner._changed_repos == set([dst_repo.repo_id])

--- a/ubipop/cli.py
+++ b/ubipop/cli.py
@@ -30,11 +30,9 @@ def parse_args(args):
                         help="path to to user cert")
     parser.add_argument('--workers', action="store", type=int, default=4,
                         help="Number of workers for parallel execution")
-    parser.add_argument('--output-changed-repos', action="store", required=False,
-                        help="Path for output file. "
-                             "If provided, file containing repo ids of changed repos is created.",)
-    parser.add_argument('--output-all-repos', action="store_true", required=False,
-                        help="If provided, write all output repos.",)
+    parser.add_argument('--output-repos', action="store", required=False,
+                        help="Path to output file."
+                             "If provided, file containing repo ids of all out repos is created.",)
 
     parsed = parser.parse_args(args)
 
@@ -62,7 +60,7 @@ def main(args):
 
     ubipop.UbiPopulate(opts.pulp_hostname, auth, opts.dry_run, opts.input,
                        opts.conf_src, opts.insecure, opts.workers,
-                       opts.output_changed_repos, opts.output_all_repos)\
+                       opts.output_repos)\
         .populate_ubi_repos()
 
 

--- a/ubipop/cli.py
+++ b/ubipop/cli.py
@@ -33,6 +33,8 @@ def parse_args(args):
     parser.add_argument('--output-changed-repos', action="store", required=False,
                         help="Path for output file. "
                              "If provided, file containing repo ids of changed repos is created.",)
+    parser.add_argument('--output-all-repos', action="store_true", required=False,
+                        help="If provided, write all output repos.",)
 
     parsed = parser.parse_args(args)
 
@@ -60,7 +62,7 @@ def main(args):
 
     ubipop.UbiPopulate(opts.pulp_hostname, auth, opts.dry_run, opts.input,
                        opts.conf_src, opts.insecure, opts.workers,
-                       opts.output_changed_repos)\
+                       opts.output_changed_repos, opts.output_all_repos)\
         .populate_ubi_repos()
 
 


### PR DESCRIPTION
New cli option intriduced --output-all-repos.
If provided along with --output-changed-repos, it will
write to output file all output repos.