### PR TITLE
Rework srpms output set creation

### DIFF
--- a/tests/test_ubipop.py
+++ b/tests/test_ubipop.py
@@ -329,6 +329,22 @@ def test_create_srpms_output_set(mock_ubipop_runner):
     assert out_srpms['tomcatjss'][0].filename == expected_src_rpm_filename
 
 
+def test_create_srpms_output_set_missings_srpm_reference(capsys, set_logging, mock_ubipop_runner):
+    set_logging.addHandler(logging.StreamHandler(sys.stdout))
+    mock_ubipop_runner.repos.packages['foo'] = \
+        [get_test_pkg(name="tomcatjss",
+                      filename="tomcatjss-7.3.6-1.el8+1944+b6c8e16f.noarch.rpm")]
+
+    mock_ubipop_runner._create_srpms_output_set()
+
+    out_srpms = mock_ubipop_runner.repos.source_rpms
+    assert len(out_srpms) == 0
+    out, err = capsys.readouterr()
+
+    assert err == ""
+    assert out.strip() == "Package tomcatjss doesn't reference its source rpm"
+
+
 @pytest.fixture()
 def mock_get_repo_pairs(ubi_repo_set):
     with patch('ubipop.UbiPopulate._get_input_and_output_repo_pairs') as get_repo_pairs:

--- a/tests/test_ubipop.py
+++ b/tests/test_ubipop.py
@@ -57,7 +57,7 @@ def get_test_repo(**kwargs):
 
 
 def get_test_pkg(**kwargs):
-    return Package(kwargs.get('name'), kwargs.get('filename'))
+    return Package(kwargs.get('name'), kwargs.get('filename'), kwargs.get('sourcerpm_filename'))
 
 
 def get_test_mod(**kwargs):
@@ -314,16 +314,19 @@ def test_create_srpms_output_set(mock_ubipop_runner):
     expected_src_rpm_filename = "tomcatjss-7.3.6-1.el8+1944+b6c8e16f.src.rpm"
     mock_ubipop_runner.repos.packages['foo'] = \
         [get_test_pkg(name="tomcatjss",
-                      filename="tomcatjss-7.3.6-1.el8+1944+b6c8e16f.noarch.rpm"),
+                      filename="tomcatjss-7.3.6-1.el8+1944+b6c8e16f.noarch.rpm",
+                      sourcerpm_filename=expected_src_rpm_filename),
          get_test_pkg(name="kernel",
-                      filename="kernel-7.3.6-1.el8+1944+b6c8e16f.noarch.rpm")
+                      filename="kernel-7.3.6-1.el8+1944+b6c8e16f.noarch.rpm",
+                      sourcerpm_filename="kernel.src.rpm")
          ]
 
     mock_ubipop_runner._create_srpms_output_set()
+
     out_srpms = mock_ubipop_runner.repos.source_rpms
     assert len(out_srpms) == 1
-    assert out_srpms[0].name == "tomcatjss"
-    assert out_srpms[0].filename == expected_src_rpm_filename
+    assert out_srpms['tomcatjss'][0].name == "tomcatjss"
+    assert out_srpms['tomcatjss'][0].filename == expected_src_rpm_filename
 
 
 @pytest.fixture()
@@ -382,8 +385,8 @@ def test_get_pulp_actions(mock_ubipop_runner, mock_current_content_ft):
     mock_ubipop_runner.repos.debug_rpms = {"test_debug_pkg":
                                            [get_test_pkg(name="test_debug_pkg",
                                                          filename="test_debug_pkg.rpm")]}
-    mock_ubipop_runner.repos.source_rpms = [get_test_pkg(name="test_srpm",
-                                                         filename="test_srpm.src.rpm")]
+    mock_ubipop_runner.repos.source_rpms = {"test_srpm": [get_test_pkg(name="test_srpm",
+                                                          filename="test_srpm.src.rpm")]}
 
     associations, unassociations = \
         mock_ubipop_runner._get_pulp_actions(*mock_current_content_ft)
@@ -433,10 +436,12 @@ def test_get_pulp_actions_no_actions(mock_ubipop_runner, mock_current_content_ft
     mock_ubipop_runner.repos.modules = {"test": [get_test_mod(name="md_current")]}
     mock_ubipop_runner.repos.packages = {"test_rpm": [get_test_pkg(name="rpm_current",
                                                       filename="rpm_current.rpm")]}
-    mock_ubipop_runner.repos.debug_rpms = [get_test_pkg(name="debug_rpm_current",
-                                                         filename="debug_rpm_current.rpm")]
-    mock_ubipop_runner.repos.source_rpms = {"test_debug_pkg": [get_test_pkg(name="srpm_current",
-                                                              filename="srpm_current.src.rpm")]}
+    mock_ubipop_runner.repos.debug_rpms = {"test_debug_pkg": [get_test_pkg(name="debug_rpm_current",
+                                                              filename="debug_rpm_current.rpm")]}
+
+    mock_ubipop_runner.repos.source_rpms = {"test_srpm": [get_test_pkg(name="srpm_current",
+                                                                       filename=
+                                                                       "srpm_current.src.rpm")]}
 
     associations, unassociations = \
         mock_ubipop_runner._get_pulp_actions(*mock_current_content_ft)

--- a/ubipop/__init__.py
+++ b/ubipop/__init__.py
@@ -270,14 +270,14 @@ class UbiPopulateRunner(object):
             self.keep_n_latest_modules(units)
 
     def _create_srpms_output_set(self):
-        rpms = list(chain.from_iterable(self.repos.packages.values()))
+        rpms = chain.from_iterable(self.repos.packages.values())
         for package in rpms:
             if package.sourcerpm_filename is None:
                 _LOG.warning("Package %s doesn't reference its source rpm", package.name)
                 continue
 
-            self.repos.source_rpms[package.name].extend([Package(package.name,
-                                                                 package.sourcerpm_filename)])
+            self.repos.source_rpms[package.name].append(Package(package.name,
+                                                                package.sourcerpm_filename))
 
         blacklisted_srpms = self.get_blacklisted_packages(
             list(chain.from_iterable(self.repos.source_rpms.values())))

--- a/ubipop/__init__.py
+++ b/ubipop/__init__.py
@@ -29,8 +29,7 @@ class UbiRepoSet(object):
         self.debug_rpms = defaultdict(list)
         self.modules = defaultdict(list)
         self.pkgs_from_modules = defaultdict(list)
-
-        self.source_rpms = []
+        self.source_rpms = defaultdict(list)
 
         self._ensure_repos_existence()
 
@@ -271,24 +270,23 @@ class UbiPopulateRunner(object):
             self.keep_n_latest_modules(units)
 
     def _create_srpms_output_set(self):
-        packages = chain.from_iterable(self.repos.packages.values())
-        for package in packages:
+        rpms = list(chain.from_iterable(self.repos.packages.values()))
+        for package in rpms:
             if package.sourcerpm_filename is None:
-                name, ver, rel, _, _ = splitFilename(package.filename)
-                package.sourcerpm_filename = "{n}-{v}-{r}.src.rpm".format(n=name, v=ver, r=rel)
+                _LOG.warning("Package %s doesn't reference its source rpm", package.name)
+                continue
 
-            self.repos.source_rpms.append(Package(package.name,
-                                                  package.sourcerpm_filename))
+            self.repos.source_rpms[package.name].extend([Package(package.name,
+                                                                 package.sourcerpm_filename)])
 
-        blacklisted = self.get_blacklisted_packages(self.repos.source_rpms)
-        self.repos.source_rpms = \
-            self._diff_packages_by_filename(self.repos.source_rpms, blacklisted)
+        blacklisted_srpms = self.get_blacklisted_packages(
+            list(chain.from_iterable(self.repos.source_rpms.values())))
+
+        for pkg in blacklisted_srpms:
+            self.repos.source_rpms.pop(pkg.name, None)
 
     def _determine_pulp_actions(self, units, current, diff_f):
-        if isinstance(units, dict):
-            expected = list(chain.from_iterable(units.values()))
-        else:
-            expected = units
+        expected = list(chain.from_iterable(units.values()))
         to_associate = diff_f(expected, current)
         to_unassociate = diff_f(current, expected)
         return to_associate, to_unassociate


### PR DESCRIPTION
Reworked srpms output set creation. Now it doesn't guess filename of srpm if its filename is not referenced on binary rpm unit.
Updated tests.