### PR TITLE
Added requests retry mechanism for all requests call in _pulp_client

### DIFF
--- a/tests/test_pulp.py
+++ b/tests/test_pulp.py
@@ -251,11 +251,3 @@ def test_retries(set_backoff_to_zero_fixture, mocked_getresponse, mock_pulp, sho
     else:
         with pytest.raises(HTTPError):
             getattr(mock_pulp, retry_call)(*retry_args)
-
-def test_retry_env_vars(mock_pulp):
-    os.environ['UBIPOP_HTTP_TOTAL_RETRIES'] = '100'
-    os.environ['UBIPOP_HTTP_RETRY_BACKOFF'] = '99'
-    reload(ubipop._pulp_client)
-    mock_pulp._make_session()
-    assert mock_pulp.adapter.max_retries.backoff_factor == 99
-    assert mock_pulp.adapter.max_retries.total == 100

--- a/tests/test_pulp.py
+++ b/tests/test_pulp.py
@@ -1,7 +1,15 @@
-from ubipop._pulp_client import Repo, Package, Pulp
-import pytest
+import mock
+import os
 import sys
+import re
+import httplib
+from requests.exceptions import HTTPError
 
+from ubipop._pulp_client import Repo, Package, Pulp, PulpRetryAdapter, HTTP_TOTAL_RETRIES
+
+import pytest
+
+import requests_mock
 
 if sys.version_info <= (2, 7,):
     import requests_mock as rm
@@ -157,3 +165,69 @@ def test_wait_for_tasks(mock_pulp, mock_search_task):
     results = mock_pulp.wait_for_tasks(["test_task"])
     assert len(results) == 1
     assert results["test_task"]['state'] == 'finished'
+
+
+@pytest.fixture()
+def mocked_getresponse():
+    with mock.patch("urllib3.connectionpool.HTTPConnectionPool._get_conn") as mocked_get_conn:
+        yield mocked_get_conn.return_value.getresponse
+
+
+@pytest.fixture()
+def set_backoff_to_zero_fixture(mock_pulp):
+    patcher = mock.patch("ubipop._pulp_client.Pulp._make_session")
+    orig = mock_pulp._make_session
+    patched = patcher.start()
+    patched.side_effect = lambda: [
+        orig(),
+        setattr(mock_pulp.adapter.max_retries, "backoff_factor", 0)
+    ]
+    yield patched
+    patcher.stop()
+
+
+def make_mock_response(status, text=None):
+    m = mock.MagicMock(name='MockResponse', status=status)
+    m.isclosed.side_effect = [False, True]
+    m.msg = mock.MagicMock(spec=httplib.HTTPMessage, headers=[], status=status)
+    m.read.return_value = text
+    return m
+
+
+@pytest.mark.parametrize(
+    "should_retry,err_status_code,env_retries,retry_call,retry_args,ok_response,expected_retries",
+    [
+        (True, 500, None, "search_repo_by_cs", (mock.MagicMock(),), '{}', HTTP_TOTAL_RETRIES),
+        (True, 500, None, "search_rpms", (mock.MagicMock(),), '[]', HTTP_TOTAL_RETRIES),
+        (True, 500, None, "search_modules", (mock.MagicMock(),), '[]', HTTP_TOTAL_RETRIES),
+        (True, 500, None, "wait_for_tasks", (['fake-tid'],),
+         '{"state":"finished","task_id":"fake-tid"}', HTTP_TOTAL_RETRIES),
+        (True, 500, None, "search_tasks", ([mock.MagicMock()],), '[]', HTTP_TOTAL_RETRIES),
+        (True, 500, None, "unassociate_units", ((2 * (mock.MagicMock(), )) + (['rpm'], )),
+         '{"spawned_tasks":[]}', HTTP_TOTAL_RETRIES),
+        (True, 500, None, "associate_units", ((3 * (mock.MagicMock(), )) + (['rpm'], )),
+         '{"spawned_tasks":[]}', HTTP_TOTAL_RETRIES),
+        (True, 500, None, "publish_repo", (
+            mock.MagicMock(distributors_ids_type_ids_tuples=[('a', 'b')]), ),
+         '{"spawned_tasks":[]}', HTTP_TOTAL_RETRIES),
+
+        (True, 500, 3, "search_repo_by_cs", (mock.MagicMock(),), '{}', 3),
+        (False, 400, 3, "search_repo_by_cs", (mock.MagicMock(),), '{}', 3),
+    ]
+)
+def test_retries(set_backoff_to_zero_fixture, mocked_getresponse, mock_pulp, should_retry, err_status_code,
+                 env_retries, retry_call, retry_args, ok_response, expected_retries):
+    global HTTP_TOTAL_RETRIES
+    if env_retries:
+        HTTP_TOTAL_RETRIES = env_retries
+
+    retries = [make_mock_response(err_status_code, 'x')
+               for _ in range(HTTP_TOTAL_RETRIES)[:-1]] + [make_mock_response(200, ok_response)]
+    mocked_getresponse.side_effect = retries
+
+    if should_retry:
+        getattr(mock_pulp, retry_call)(*retry_args)
+        assert len(mocked_getresponse.mock_calls) == expected_retries
+    else:
+        with pytest.raises(HTTPError):
+            getattr(mock_pulp, retry_call)(*retry_args)

--- a/tests/test_pulp.py
+++ b/tests/test_pulp.py
@@ -1,8 +1,3 @@
-try:
-    from importlib import reload
-except ImportError:
-    pass
-
 import mock
 import os
 import six
@@ -281,7 +276,7 @@ def test_retries(set_backoff_to_zero_fixture, mocked_getresponse, mock_pulp, sho
             HTTP_TOTAL_RETRIES = env_retries
 
         retries = [make_mock_response(err_status_code, 'Fake Http error')
-                   for _ in range(HTTP_TOTAL_RETRIES)[:-1]]
+                   for _ in range(HTTP_TOTAL_RETRIES-1)]
         retries.extend([make_mock_response(200, ok_response)])
         mocked_getresponse.side_effect = retries
 

--- a/ubipop/_pulp_client.py
+++ b/ubipop/_pulp_client.py
@@ -13,7 +13,7 @@ except ImportError:
 _LOG = logging.getLogger("ubipop")
 
 HTTP_TOTAL_RETRIES = int(os.environ.get("UBIPOP_HTTP_TOTAL_RETRIES", 10))
-HTTP_RETRY_BACKOFF = int(os.environ.get("UBIPOP_HTTP_RETRY_BACKOFF", 1))
+HTTP_RETRY_BACKOFF = float(os.environ.get("UBIPOP_HTTP_RETRY_BACKOFF", 1))
 
 
 class UnsupportedTypeId(Exception):

--- a/ubipop/_pulp_client.py
+++ b/ubipop/_pulp_client.py
@@ -1,6 +1,5 @@
 import requests
 from requests.packages.urllib3.util.retry import Retry
-from requests.adapters import HTTPAdapter
 import os
 
 import time
@@ -31,8 +30,6 @@ class PulpRetryAdapter(requests.adapters.HTTPAdapter):
         )
         super(PulpRetryAdapter, self).__init__(*args, **kwargs)
 
-    def send(self, *args, **kwargs):
-        return super(PulpRetryAdapter, self).send(*args, **kwargs)
 
 class Pulp(object):
     PULP_API = "/pulp/api/v2/"

--- a/ubipop/_pulp_client.py
+++ b/ubipop/_pulp_client.py
@@ -1,5 +1,5 @@
 import requests
-from requests.packages.urllib3.util.retry import Retry
+from urllib3.util.retry import Retry
 import os
 
 import time

--- a/ubipop/_pulp_client.py
+++ b/ubipop/_pulp_client.py
@@ -12,8 +12,8 @@ except ImportError:
 
 _LOG = logging.getLogger("ubipop")
 
-HTTP_TOTAL_RETRIES = os.environ.get("UBIPOP_HTTP_TOTAL_RETRIES", 10)
-UBIPOP_HTTP_RETRY_BACKOFF = os.environ.get("UBIPOP_HTTP_RETRY_BACKOFF", 1)
+HTTP_TOTAL_RETRIES = int(os.environ.get("UBIPOP_HTTP_TOTAL_RETRIES", 10))
+HTTP_RETRY_BACKOFF = int(os.environ.get("UBIPOP_HTTP_RETRY_BACKOFF", 1))
 
 
 class UnsupportedTypeId(Exception):
@@ -26,7 +26,7 @@ class PulpRetryAdapter(requests.adapters.HTTPAdapter):
             total=kwargs.get('total_retries', HTTP_TOTAL_RETRIES),
             status_forcelist=[500, 502, 503, 504],
             method_whitelist=["HEAD", "TRACE", "GET", "POST", "PUT", "OPTIONS", "DELETE"],
-            backoff_factor=kwargs.get('backoff_factor', UBIPOP_HTTP_RETRY_BACKOFF)
+            backoff_factor=kwargs.get('backoff_factor', HTTP_RETRY_BACKOFF)
         )
         super(PulpRetryAdapter, self).__init__(*args, **kwargs)
 


### PR DESCRIPTION
To make sure tool process isn't interrupted due network issues,
retry mechanism based on urllib3 Retry was implemented.
New configuration environment variables to customize this
were added:

- UBIPOP_HTTP_TOTAL_RETRIES
- UBIPOP_HTTP_RETRY_BACKOFF

fixes #32