### PR TITLE
Copy modulemd_defaults units as well while populating ubi repos

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,6 @@
 import pytest
 from ubipop._utils import (PulpAction, AssociateAction, AssociateActionModules,
+                           AssociateActionModuleDefaults, UnassociateActionModuleDefaults,
                            AssociateActionRpms, UnassociateActionRpms,
                            UnassociateActionModules)
 from ubipop._pulp_client import Repo
@@ -23,6 +24,7 @@ def test_raise_not_implemented_associate_action():
 
 @pytest.mark.parametrize("klass, method",
                          [(AssociateActionModules, "associate_modules"),
+                          (AssociateActionModuleDefaults, "associate_module_defaults"),
                           (AssociateActionRpms, "associate_packages")]
                          )
 def test_get_action_associate(klass, method):
@@ -41,6 +43,7 @@ def test_get_action_associate(klass, method):
 
 @pytest.mark.parametrize("klass, method",
                          [(UnassociateActionModules, "unassociate_modules"),
+                          (UnassociateActionModuleDefaults, "unassociate_module_defaults"),
                           (UnassociateActionRpms, "unassociate_packages")]
                          )
 def test_get_action_unassociate(klass, method):

--- a/ubipop/_pulp_client.py
+++ b/ubipop/_pulp_client.py
@@ -102,6 +102,22 @@ class Pulp(object):
                                   metadata['arch'], metadata['artifacts'], metadata['profiles']))
         return modules
 
+    def search_module_defaults(self, repo, name, stream):
+        url = "repositories/{REPO_ID}/search/units/".format(REPO_ID=repo.repo_id)
+        criteria = {
+            "type_ids": ["modulemd_defaults"],
+            "filters": {"unit": {"name": name, "stream": stream}}
+        }
+        payload = {"criteria": criteria}
+        ret = self.do_request("post", url, payload)
+        ret.raise_for_status()
+        module_defaults = []
+        for item in ret.json():
+            metadata = item['metadata']
+            module_defaults.append(ModuleDefaults(metadata['name'], metadata['stream'],
+                                                  metadata['profiles']))
+        return module_defaults
+
     def wait_for_tasks(self, task_id_list, delay=5.0):
         results = {}
 
@@ -134,6 +150,16 @@ class Pulp(object):
                                         {'arch': module.arch}
                                         ]})
 
+        return query_list
+
+    def _module_defaults_query(self, module_defaults):
+        query_list = []
+        for md_d in module_defaults:
+            query_list.append({'$and': [
+                                    {'name': md_d.name},
+                                    {'stream': md_d.stream},
+                                    {'profiles': md_d.profiles}
+                                ]})
         return query_list
 
     def _rpms_query(self, rpms):
@@ -182,7 +208,8 @@ class Pulp(object):
     def _get_query_list(self, type_ids, units):
         if "modulemd" in type_ids:
             query_list = self._modules_query(units)
-
+        elif "modulemd_defaults" in type_ids:
+            query_list = self._module_defaults_query(units)
         elif "rpm" in type_ids or "srpm" in type_ids:
             query_list = self._rpms_query(units)
         else:
@@ -193,11 +220,17 @@ class Pulp(object):
     def associate_modules(self, src_repo, dst_repo, modules):
         return self.associate_units(src_repo, dst_repo, modules, ("modulemd", ))
 
+    def associate_module_defaults(self, src_repo, dst_repo, module_defaults):
+        return self.associate_units(src_repo, dst_repo, module_defaults, ("modulemd_defaults", ))
+
     def associate_packages(self, src_repo, dst_repo, rpms):
         return self.associate_units(src_repo, dst_repo, rpms, ("rpm", "srpm"))
 
     def unassociate_modules(self, repo, modules):
         return self.unassociate_units(repo, modules, ("modulemd", ))
+
+    def unassociate_module_defaults(self, repo, module_defaults):
+        return self.unassociate_units(repo, module_defaults, ("modulemd_defaults", ))
 
     def unassociate_packages(self, repo, rpms):
         return self.unassociate_units(repo, rpms, ("rpm", "srpm"))
@@ -268,3 +301,40 @@ class Module(object):
 
     def __str__(self):
         return self.nsvca
+
+
+class ModuleDefaults(object):
+    """
+    module_defaults unit, defines which profiles are enabled by default when activating
+    a module. For example:
+    {...,
+     "name": "ruby",
+     "profiles": {
+        "2.5": [
+            "common"]
+        },
+    ...
+    }
+    if someone asks to enable 'ruby:2.5' for some repo without specifing profiles, will
+    get 'common' profile by defualt
+    """
+    def __init__(self, name, stream, profiles):
+        self.name = name
+        self.stream = stream
+        self.profiles = profiles  # a dict such as {'4.046':['common']}
+
+    def __str__(self):
+        return self.name
+
+    @property
+    def name_profiles(self):
+        """
+        flatten the profles and prepend name
+        format: name:[key:profile,profile]:[key:profile]
+        'ruby:[2.5:common,unique]'
+        """
+        result = self.name
+        for key in sorted(self.profiles):
+            result += ':[%s:%s]' % (key, ','.join(sorted(self.profiles[key])))
+        return result
+

--- a/ubipop/_utils.py
+++ b/ubipop/_utils.py
@@ -62,6 +62,19 @@ class UnassociateActionModules(PulpAction):
         return pulp_client_inst.unassociate_modules, self.dst_repo, self.units
 
 
+class AssociateActionModuleDefaults(AssociateAction):
+    TYPE = "module_defaults"
+
+    def get_action(self, pulp_client_inst):
+        return pulp_client_inst.associate_module_defaults, self.src_repo, self.dst_repo, self.units
+
+
+class UnassociateActionModuleDefaults(PulpAction):
+    TYPE = "module_defaults"
+
+    def get_action(self, pulp_client_inst):
+        return pulp_client_inst.unassociate_module_defaults, self.dst_repo, self.units
+
 class AssociateActionRpms(AssociateAction):
     TYPE = "packages"
 


### PR DESCRIPTION
If there modulemd_defaults for specific modulemd in the same repo,
then it should be copied to the ubi repos.
Ubipop now looks for modulemd_defaults units after searching modulemd
units with the same name and stream. If there's any, add it to push
queue.
This fixes #56
