### PR TITLE
Use cmp_version package for version comparison

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 requests
 more_executors
 ubi_config
-rpm-vercmp
+cmp_version
 futures; python_version < '3'

--- a/tests/test_ubipop.py
+++ b/tests/test_ubipop.py
@@ -124,15 +124,15 @@ def test_packages_names_by_profiles_all_profiles(mock_ubipop_runner):
 
 def test_sort_packages(mock_ubipop_runner):
     packages = [
-        get_test_pkg(filename="tomcatjss-7.3.6-1.el8+1944+b6c8e16f.noarch.rpm"),
-        get_test_pkg(filename="tomcatjss-5.3.6-1.el8+1944+b6c8e16f.noarch.rpm"),
-        get_test_pkg(filename="tomcatjss-9.3.6-1.el8+1944+b6c8e16f.noarch.rpm")]
+        get_test_pkg(filename="rubygems-2.0.14.1-34.el7_6.noarch.rpm"),
+        get_test_pkg(filename="rubygems-2.0.14-25.el7_1.noarch.rpm"),
+        get_test_pkg(filename="rubygems-2.0.13.1-34.el7_6.noarch.rpm")]
 
     mock_ubipop_runner.sort_packages(packages)
 
-    assert "5.3.6" in packages[0].filename
-    assert "7.3.6" in packages[1].filename
-    assert "9.3.6" in packages[2].filename
+    assert "2.0.13.1-34" in packages[0].filename
+    assert "2.0.14-25" in packages[1].filename
+    assert "2.0.14.1-34" in packages[2].filename
 
 
 def test_keep_n_latest_modules(mock_ubipop_runner):

--- a/tests/test_ubipop.py
+++ b/tests/test_ubipop.py
@@ -124,15 +124,21 @@ def test_packages_names_by_profiles_all_profiles(mock_ubipop_runner):
 
 def test_sort_packages(mock_ubipop_runner):
     packages = [
-        get_test_pkg(filename="rubygems-2.0.14.1-34.el7_6.noarch.rpm"),
+        get_test_pkg(filename="rubygems-2.0.14-26.el7_1.noarch.rpm"),
         get_test_pkg(filename="rubygems-2.0.14-25.el7_1.noarch.rpm"),
-        get_test_pkg(filename="rubygems-2.0.13.1-34.el7_6.noarch.rpm")]
+        get_test_pkg(filename="rubygems-2.0.14.1-33.el7_6.noarch.rpm"),
+        get_test_pkg(filename="rubygems-2.0.14.1-34.el7_6.noarch.rpm"),
+        get_test_pkg(filename="rubygems-2.0.13.1-34.el7_6.noarch.rpm"),
+        get_test_pkg(filename="rubygems-2.0.13.2-34.el7_6.noarch.rpm")]
 
     mock_ubipop_runner.sort_packages(packages)
 
     assert "2.0.13.1-34" in packages[0].filename
-    assert "2.0.14-25" in packages[1].filename
-    assert "2.0.14.1-34" in packages[2].filename
+    assert "2.0.13.2-34" in packages[1].filename
+    assert "2.0.14-25" in packages[2].filename
+    assert "2.0.14-26" in packages[3].filename
+    assert "2.0.14.1-33" in packages[4].filename
+    assert "2.0.14.1-34" in packages[5].filename
 
 
 def test_keep_n_latest_modules(mock_ubipop_runner):

--- a/ubipop/_pulp_client.py
+++ b/ubipop/_pulp_client.py
@@ -1,7 +1,7 @@
 import requests
 import time
 import logging
-from rpm_vercmp import vercmp
+from cmp_version import cmp_version
 try:
     from urllib.parse import urljoin
 except ImportError:
@@ -266,22 +266,22 @@ class Package(object):
         self.is_modular = is_modular
 
     def __lt__(self, other):
-        return vercmp(self.filename, other.filename) < 0
+        return cmp_version(self.filename, other.filename) < 0
 
     def __gt__(self, other):
-        return vercmp(self.filename, other.filename) > 0
+        return cmp_version(self.filename, other.filename) > 0
 
     def __eq__(self, other):
-        return vercmp(self.filename, other.filename) == 0
+        return cmp_version(self.filename, other.filename) == 0
 
     def __le__(self, other):
-        return vercmp(self.filename, other.filename) <= 0
+        return cmp_version(self.filename, other.filename) <= 0
 
     def __ge__(self, other):
-        return vercmp(self.filename, other.filename) >= 0
+        return cmp_version(self.filename, other.filename) >= 0
 
     def __ne__(self, other):
-        return vercmp(self.filename, other.filename) != 0
+        return cmp_version(self.filename, other.filename) != 0
 
     def __str__(self):
         return self.filename


### PR DESCRIPTION
Previously used rpm-vercmp was unreliable for
some variants of version, so this commit
moves to cmp_version python package which
is more reliable.

Fix #66 .