### PR TITLE
Include all module packages if no profile is defined

### DIFF
--- a/tests/data/ubiconf_golang.yaml
+++ b/tests/data/ubiconf_golang.yaml
@@ -1,0 +1,52 @@
+content_sets:
+  rpm:
+    output: ubi-8-for-x86_64-appstream-rpms
+    input: rhel-8-for-x86_64-appstream-rpms
+  srpm:
+    output: ubi-8-for-x86_64-appstream-source-rpms
+    input: rhel-8-for-x86_64-appstream-source-rpms
+  debuginfo:
+    output: ubi-8-for-x86_64-appstream-debug-rpms
+    input: rhel-8-for-x86_64-appstream-debug-rpms
+
+arches:
+  - src
+  - x86_64
+
+packages:
+  include:
+  - go-srpm-macros.*
+  - go-toolset.*
+  - golang.*
+  - golang-bin.*
+  - golang-docs.*
+  - golang-misc.*
+  - golang-race.*
+  - golang-src.*
+  - golang-tests.*
+  exclude:
+  - python36
+  - kernel
+  - kernel-doc
+  - kmod-kvdo
+  - kernel.src
+  - kernel-debug-debuginfo
+  - kernel-debuginfo
+  - kernel-debuginfo-common-aarch64
+  - kernel-debuginfo-common-ppc64le
+  - kernel-debuginfo-common-s390x
+  - kernel-debuginfo-common-x86_64
+  - kernel-tools-debuginfo
+  - linux-firmware
+  - grub2
+  - grub2-common
+  - grub2-tools
+  - grub2-tools-minimal
+  - grubby
+  - redhat-release-eula
+  - s390utils-base
+
+modules:
+  include:
+  - name: go-toolset
+    stream: rhel8

--- a/tests/test_ubipop.py
+++ b/tests/test_ubipop.py
@@ -87,7 +87,7 @@ def test_get_output_repo_ids_no_debug(ubi_repo_set_no_debug):
     assert repo_ids == set(["ubi-foo-rpms", "ubi-foo-source"])
 
 
-def test_get_packages_from_module(mock_ubipop_runner):
+def test_get_packages_from_module_by_name(mock_ubipop_runner):
     package_name = "postgresql"
     input_modules = \
         [get_test_mod(
@@ -97,12 +97,26 @@ def test_get_packages_from_module(mock_ubipop_runner):
                       "postgresql-contrib-debuginfo-0:9.6.10-1.module+el8+2470+d1bafa0e.x86_64"]
                       )]
 
-    pkgs_from_modules = mock_ubipop_runner.get_packages_from_module(package_name, input_modules)
+    pkgs_from_modules = mock_ubipop_runner.get_packages_from_module(input_modules, package_name)
     assert len(pkgs_from_modules) == 1
     pkg = pkgs_from_modules[0]
     assert pkg.name == "postgresql"
     # filename is without  epoch
     assert pkg.filename == "postgresql-9.6.10-1.module+el8+2470+d1bafa0e.x86_64.rpm"
+
+
+def test_get_packages_from_module(mock_ubipop_runner):
+    input_modules = \
+        [get_test_mod(
+            packages=["postgresql-0:9.6.10-1.module+el8+2470+d1bafa0e.src",
+                      "postgresql-0:9.6.10-1.module+el8+2470+d1bafa0e.x86_64",
+                      "postgresql-contrib-0:9.6.10-1.module+el8+2470+d1bafa0e.x86_64",
+                      "postgresql-contrib-debuginfo-0:9.6.10-1.module+el8+2470+d1bafa0e.x86_64"]
+                      )]
+
+    pkgs_from_modules = mock_ubipop_runner.get_packages_from_module(input_modules)
+    assert len(pkgs_from_modules) == 3
+    pkg = pkgs_from_modules[0]
 
 
 def test_packages_names_by_profiles(mock_ubipop_runner):

--- a/tests/test_ubipop.py
+++ b/tests/test_ubipop.py
@@ -245,6 +245,32 @@ def test_match_modules(mock_ubipop_runner):
     assert pkg.filename == "tomcatjss-7.3.6-1.el8+1944+b6c8e16f.noarch.rpm"
     assert pkg.filename == "tomcatjss-7.3.6-1.el8+1944+b6c8e16f.noarch.rpm"
 
+
+def test_match_modules_without_profile(ubi_repo_set, executor):
+    test_ubiconf = ubiconfig.get_loader(TEST_DATA_DIR).load('ubiconf_golang.yaml')
+    mocked_ubipop_runner = UbiPopulateRunner(MagicMock(), ubi_repo_set, test_ubiconf, False, executor)
+    mocked_ubipop_runner.pulp.search_modules.return_value = \
+        [get_test_mod(name="go-toolset",
+                      profiles={"common": ["go-toolset"]},
+                      packages=[
+                          "go-toolset-0:1.11.5-1.module+el8+2774+11afa8b5.x86_64",
+                          "golang-0:1.11.5-1.module+el8+2774+11afa8b5.x86_64",
+                          "golang-bin-0:1.11.5-1.module+el8+2774+11afa8b5.x86_64",
+                          "golang-docs-0:1.11.5-1.module+el8+2774+11afa8b5.noarch",
+                          "golang-misc-0:1.11.5-1.module+el8+2774+11afa8b5.noarch",
+                          "golang-race-0:1.11.5-1.module+el8+2774+11afa8b5.x86_64",
+                          "golang-src-0:1.11.5-1.module+el8+2774+11afa8b5.noarch",
+                          "golang-tests-0:1.11.5-1.module+el8+2774+11afa8b5.noarch",
+                      ])]
+
+    mocked_ubipop_runner._match_modules()
+
+    assert len(mocked_ubipop_runner.repos.modules) == 1
+    assert len(mocked_ubipop_runner.repos.modules['go-toolsetrhel8']) == 1
+    assert mocked_ubipop_runner.repos.modules['go-toolsetrhel8'][0].name == 'go-toolset'
+    assert len(mocked_ubipop_runner.repos.pkgs_from_modules['go-toolsetrhel8']) == 8
+
+
 def test_match_module_defaults(mock_ubipop_runner):
     mock_ubipop_runner.repos.modules['n1s1'] = [get_test_mod(name="virt",
                                                              profiles={'2.5': ["common"]},


### PR DESCRIPTION
Packages for modules are included based on the package name present in
the repositories module profiles. This leads to missing packages in the
output repositories, as not every package required is included in module
profiles.

In this change, if no module profile is defined in the UBI
configuration, include every package present in the module artifacts.

Fix #81