### PR TITLE
Run tests on Python 3.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,8 @@ matrix:
   - python: '2.7'
     env: TOX_ENV=py27
   - python: '3.5'
+    env: TOX_ENV=py35
+  - python: '3.5'
     env: TOX_ENV=static
   - python: '3.5'
     env: TOX_ENV=cov-travis DEPLOY=1


### PR DESCRIPTION
Tests should also run against Python 3.5.