### PR TITLE
Fixed inconsistency in Package initializations

### DIFF
--- a/tests/test_ubipop.py
+++ b/tests/test_ubipop.py
@@ -59,8 +59,9 @@ def get_test_repo(**kwargs):
 
 
 def get_test_pkg(**kwargs):
-    return Package(kwargs.get('name'), kwargs.get('filename'), kwargs.get('sourcerpm_filename'),
-                   kwargs.get('is_modular', False))
+    return Package(kwargs.get('name'), kwargs.get('filename'),
+                   sourcerpm_filename=kwargs.get('sourcerpm_filename'),
+                   is_modular=kwargs.get('is_modular', False))
 
 
 def get_test_mod(**kwargs):

--- a/ubipop/__init__.py
+++ b/ubipop/__init__.py
@@ -314,8 +314,9 @@ class UbiPopulateRunner(object):
                 _LOG.warning("Package %s doesn't reference its source rpm", package.name)
                 continue
 
-            self.repos.source_rpms[package.name].append(Package(package.name,
-                                                                package.sourcerpm_filename))
+            self.repos.source_rpms[package.name].append(
+                Package(package.name, package.sourcerpm_filename)
+            )
 
         blacklisted_srpms = self.get_blacklisted_packages(
             list(chain.from_iterable(self.repos.source_rpms.values())))

--- a/ubipop/_pulp_client.py
+++ b/ubipop/_pulp_client.py
@@ -103,8 +103,9 @@ class Pulp(object):
         ret.raise_for_status()
         for item in ret.json():
             metadata = item['metadata']
-            rpms.append(Package(metadata['name'], metadata['filename'], metadata.get('sourcerpm'),
-                                metadata.get('is_modular', False)))
+            rpms.append(Package(metadata['name'], metadata['filename'],
+                                sourcerpm_filename=metadata.get('sourcerpm'),
+                                is_modular=metadata.get('is_modular', False)))
         return rpms
 
     def search_modules(self, repo, name=None, stream=None):


### PR DESCRIPTION
is_modular adn sourcerpm_filename are keyword arguments, therefore
they should be as well passed as keyword arguments