### PR TITLE
Reworked matching modular rpms

### DIFF
--- a/ubipop/__init__.py
+++ b/ubipop/__init__.py
@@ -615,7 +615,7 @@ class UbiPopulateRunner(object):
                 modules to process
 
         Returns:
-            set of str:
+            list of str:
                 names of packages within matching modules & profiles
         """
         packages_names = []

--- a/ubipop/_pulp_client.py
+++ b/ubipop/_pulp_client.py
@@ -81,7 +81,7 @@ class Pulp(object):
 
         return repos
 
-    def search_rpms(self, repo, name=None, arch=None, name_globbing=False):
+    def search_rpms(self, repo, name=None, arch=None, name_globbing=False, filename=None):
         url = "repositories/{REPO_ID}/search/units/".format(REPO_ID=repo.repo_id)
         criteria = {"type_ids": ["rpm", "srpm"]}
 
@@ -92,11 +92,13 @@ class Pulp(object):
             else:
                 filters["filters"]["unit"]["name"] = name
 
-            criteria.update(filters)
         if arch:
             filters["filters"]["unit"]["arch"] = arch
-            criteria.update(filters)
 
+        if filename:
+            filters["filters"]["unit"]["filename"] = filename
+
+        criteria.update(filters)
         payload = {"criteria": criteria}
         ret = self.do_request("post", url, payload)
         rpms = []
@@ -105,6 +107,7 @@ class Pulp(object):
             metadata = item['metadata']
             rpms.append(Package(metadata['name'], metadata['filename'], metadata.get('sourcerpm'),
                                 metadata.get('is_modular', False)))
+
         return rpms
 
     def search_modules(self, repo, name=None, stream=None):


### PR DESCRIPTION
This commit includes more precise handling
of modular packages. Every rpm is checked againts
pulp if it exists in binary rpm or debug rpm repo
and then rpm is added accordingly.
This leads to correct assocications of debug rpms
and also correct references for source rpms
of modular packages.

Also fixed overlapping package names in profiles
which won't duplicated now.

Fixes #24 #52  #27 