### PR TITLE
Fix minor issues in requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 requests
-more_executors
-ubi_config
+more-executors
+ubi-config
 cmp_version
-futures; python_version < '3'

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -4,4 +4,3 @@ mock
 requests-mock; python_version > '2.6'
 requests-mock==1.3.0; python_version == '2.6'
 pytest-catchlog; python_version == '2.6'
-more_executors


### PR DESCRIPTION
- Correct library names are ubi-config, more-executors (i.e. '-'
  and not '_'). During pip install, the names are normalized so this
  doesn't make a difference, but it does break some other tools
  such as https://libraries.io/pypi/ubi-population-tool.

- There's no need to repeat same dependency in test-requirements.txt
  and requirements.txt

- There's no need to repeat a transitive dependency (futures) as
  a direct dependency in requirements.txt