### PR TITLE
Keep all mds with same name:stream:version

### DIFF
--- a/ubipop/__init__.py
+++ b/ubipop/__init__.py
@@ -605,7 +605,14 @@ class UbiPopulateRunner(object):
         """
         Keeps n latest modules in modules sorted list
         """
-        modules[:] = modules[-n:]
+        modules_to_keep = []
+        versions_to_keep = sorted(set([m.version for m in modules]))[-n:]
+
+        for module in modules:
+            if module.version in versions_to_keep:
+                modules_to_keep.append(module)
+
+        modules[:] = modules_to_keep
 
     def sort_packages(self, packages):
         """


### PR DESCRIPTION
Previously when we got more modules with the same
name, stream and version, it was undefined which one
goes to output ubi repo. It may have resulted into failed
dependency check during installation of packages.

Now in these cases we take all modules that differs only context
but the same name:stream:version.

Fixes #100 