### PR TITLE
Replace cmp_version with rpm python bindings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 sudo: false
 language: python
+before_install:
+  # for rpm-py-installer
+  - sudo apt-get install -y rpm
+
 install: pip install tox
 matrix:
   include:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 requests
 more-executors
 ubi-config
-cmp_version
+rpm-py-installer

--- a/tests/test_ubipop.py
+++ b/tests/test_ubipop.py
@@ -206,19 +206,22 @@ def test_sort_packages(mock_ubipop_runner):
         get_test_pkg(filename="rubygems-2.0.14-26.el7_1.noarch.rpm"),
         get_test_pkg(filename="rubygems-2.0.14-25.el7_1.noarch.rpm"),
         get_test_pkg(filename="rubygems-2.0.14.1-33.el7_6.noarch.rpm"),
-        get_test_pkg(filename="rubygems-2.0.14.1-34.el7_6.noarch.rpm"),
+        get_test_pkg(filename="rubygems-2.0.14.1-34.1.el7_6.noarch.rpm"),
+        get_test_pkg(filename="rubygems-2.0.14.1-34.1.1.el7_6.noarch.rpm"),
         get_test_pkg(filename="rubygems-2.0.13.1-34.el7_6.noarch.rpm"),
         get_test_pkg(filename="rubygems-2.0.13.2-34.el7_6.noarch.rpm"),
     ]
 
     mock_ubipop_runner.sort_packages(packages)
 
-    assert "2.0.13.1-34" in packages[0].filename
-    assert "2.0.13.2-34" in packages[1].filename
-    assert "2.0.14-25" in packages[2].filename
-    assert "2.0.14-26" in packages[3].filename
-    assert "2.0.14.1-33" in packages[4].filename
-    assert "2.0.14.1-34" in packages[5].filename
+    assert "2.0.13.1-34.el7_6" in packages[0].filename
+    assert "2.0.13.2-34.el7_6" in packages[1].filename
+    assert "2.0.14-25.el7_1" in packages[2].filename
+    assert "2.0.14-26.el7_1" in packages[3].filename
+    assert "2.0.14.1-33.el7_6" in packages[4].filename
+    assert "2.0.14.1-34.1.el7_6" in packages[5].filename
+    assert "2.0.14.1-34.1.1.el7_6" in packages[6].filename
+
 
 @pytest.mark.parametrize("n, expected_versions_modules",
                          [(1, {3: 2}), (2, {2: 3, 3: 2}), (3, {1: 1, 2: 3, 3: 2})])

--- a/ubipop/_pulp_client.py
+++ b/ubipop/_pulp_client.py
@@ -4,6 +4,7 @@ import threading
 import time
 
 from urllib3.util.retry import Retry
+from ubipop._utils import split_filename
 
 try:
     from urllib.parse import urljoin
@@ -11,8 +12,8 @@ except ImportError:
     from urlparse import urljoin
 
 import requests
+from rpm import labelCompare as label_compare  # pylint: disable=no-name-in-module
 
-from cmp_version import cmp_version
 
 _LOG = logging.getLogger("ubipop")
 
@@ -296,24 +297,27 @@ class Package(object):
         self.filename = filename
         self.sourcerpm_filename = sourcerpm_filename
         self.is_modular = is_modular
+        #  return name, ver, rel, epoch, arch
+        _, self.version, self.release, self.epoch, _ = split_filename(self.filename)
+        self.evr_tuple = (self.epoch, self.version, self.release)
 
     def __lt__(self, other):
-        return cmp_version(self.filename, other.filename) < 0
+        return label_compare(self.evr_tuple, other.evr_tuple) < 0
 
     def __gt__(self, other):
-        return cmp_version(self.filename, other.filename) > 0
+        return label_compare(self.evr_tuple, other.evr_tuple) > 0
 
     def __eq__(self, other):
-        return cmp_version(self.filename, other.filename) == 0
+        return label_compare(self.evr_tuple, other.evr_tuple) == 0
 
     def __le__(self, other):
-        return cmp_version(self.filename, other.filename) <= 0
+        return label_compare(self.evr_tuple, other.evr_tuple) <= 0
 
     def __ge__(self, other):
-        return cmp_version(self.filename, other.filename) >= 0
+        return label_compare(self.evr_tuple, other.evr_tuple) >= 0
 
     def __ne__(self, other):
-        return cmp_version(self.filename, other.filename) != 0
+        return label_compare(self.evr_tuple, other.evr_tuple) != 0
 
     def __str__(self):
         return self.filename


### PR DESCRIPTION
This change replaces buggy cmp_version package
with python bindings of official rpm project.

This should ensure that ubipop will sort rpms by correctly implemented and maitained vercmp algorithm.

Fixes #104 