### PR TITLE
Conditional creation of install_requires of rpm distribution

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 requests
 more-executors
 ubi-config
-rpm-py-installer

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 from setuptools import setup
+import pkg_resources
 
 
 def get_description():
@@ -14,9 +15,24 @@ def get_long_description():
     return text[idx:]
 
 
+def get_rpm_distribution():
+    for distribution in ['rpm', 'rpm-python']:
+        try:
+            pkg_resources.get_distribution(distribution)
+        except pkg_resources.DistributionNotFound:
+            continue
+        else:
+            return distribution
+    return 'rpm-py-installer'
+
+
 def get_requirements():
+    requirements = [get_rpm_distribution()]
+
     with open('requirements.txt') as f:
-        return f.read().splitlines()
+        requirements.extend(f.read().splitlines())
+
+    return requirements
 
 
 setup(name='ubi-population-tool',


### PR DESCRIPTION
This commit adds conditional creation of install_requires list
in setup.py for rpm distribution.
If rpm-py-installer was added there unconditionally,
rpm of ubipop couldn't be installed on some envs.
If implemented this way there is no need to change
anything in .spec file for rpm builds.

This fix is based on rpm-py-installer docs:
See Q6 in FAQ ->
https://github.com/junaruga/rpm-py-installer/blob/master/docs/users_guide.md