### PR TITLE
Explicit dist: trusty in travis.yml for py26 env

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-dist: trusty
 sudo: false
 language: python
 before_install:
@@ -10,6 +9,7 @@ matrix:
   include:
   - python: '2.6'
     env: TOX_ENV=py26
+    dist: trusty
   - python: '2.7'
     env: TOX_ENV=py27
   - python: '3.5'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: trusty
 sudo: false
 language: python
 before_install:


### PR DESCRIPTION
This change explicitly sets dist in travis
to 'trusty' for py26 env.
The reason is that 'xenial' was made default dist on travis
recently and it does not support python 2.6 anymore.