### PR TITLE
Remove duplicate associations for srpm packages (#74)

### DIFF
--- a/tests/test_ubipop.py
+++ b/tests/test_ubipop.py
@@ -903,6 +903,39 @@ def test_log_pulp_action_no_actions(capsys, set_logging, mock_ubipop_runner):
     assert unassoc_line.strip() == "No unassociation expected for modules from test_dst"
 
 
+def test_get_pulp_no_duplicates(mock_ubipop_runner, mock_current_content_ft):
+
+    mock_ubipop_runner.repos.modules = {"test": [get_test_mod(name="md_current")]}
+    mock_ubipop_runner.repos.module_defaults = \
+        {"test": [get_test_mod_defaults(name='mdd_current',
+                                        stream='rhel',
+                                        profiles={'2.5': 'common'})]}
+    mock_ubipop_runner.repos.packages = {"test_rpm": [get_test_pkg(name="rpm_current",
+                                                                   filename="rpm_current.rpm")]}
+    mock_ubipop_runner.repos.debug_rpms = {"test_debug_pkg": [get_test_pkg(name="debug_rpm_current",
+                                                                           filename="debug_rpm_current.rpm")]}
+
+    mock_ubipop_runner.repos.source_rpms = {"test_srpm": [get_test_pkg(name="test_srpm",
+                                                                       filename=
+                                                                       "srpm_current.src.rpm")],
+                                            "test_pkg": [get_test_pkg(name="test_pkg",
+                                                                      filename=
+                                                                      "srpm_new.src.rpm")],
+                                            "foo_pkg": [get_test_pkg(name="foo_pkg",
+                                                                     filename=
+                                                                     "srpm_new.src.rpm")],
+                                            "bar_pkg": [get_test_pkg(name="bar_pkg",
+                                                                     filename=
+                                                                     "srpm_new_next.src.rpm")]}
+
+    associations, _, _, _ = \
+        mock_ubipop_runner._get_pulp_actions(*mock_current_content_ft) # pylint: disable=W0212
+
+    _, _, srpms, _ = associations
+    # only two srpm associations, no duplicates
+    assert len(srpms.units) == 2
+
+
 def test_associate_units(mock_ubipop_runner):
     src_repo = get_test_repo(repo_id='test_src')
     dst_repo = get_test_repo(repo_id='test_dst')

--- a/ubipop/__init__.py
+++ b/ubipop/__init__.py
@@ -376,6 +376,19 @@ class UbiPopulateRunner(object):
     def _get_pulp_actions_pkgs(self, pkgs, current):
         return self._determine_pulp_actions(pkgs, current, self._diff_packages_by_filename)
 
+    def _get_pulp_actions_src_pkgs(self, pkgs, current):
+        src_pkgs = {}
+        uniq_srpms = {}
+        for _, pkgs in pkgs.items():
+            for pkg in pkgs:
+                fn = pkg.filename or pkg.sourcerpm_filename
+                uniq_srpms[fn] = pkg
+
+        for _, srpm in uniq_srpms.items():
+            src_pkgs[srpm.name] = [srpm]
+
+        return self._determine_pulp_actions(src_pkgs, current, self._diff_packages_by_filename)
+
     def _get_pulp_actions(self, current_modules_ft, current_module_defaults_ft, current_rpms_ft,
                           current_srpms_ft, current_debug_rpms_ft):
         """
@@ -394,8 +407,8 @@ class UbiPopulateRunner(object):
 
         rpms_assoc, rpms_unassoc = self._get_pulp_actions_pkgs(self.repos.packages,
                                                                current_rpms_ft.result())
-        srpms_assoc, srpms_unassoc = self._get_pulp_actions_pkgs(self.repos.source_rpms,
-                                                                 current_srpms_ft.result())
+        srpms_assoc, srpms_unassoc = self._get_pulp_actions_src_pkgs(self.repos.source_rpms,
+                                                                     current_srpms_ft.result())
 
         debug_assoc = None
         debug_unassoc = None

--- a/ubipop/__init__.py
+++ b/ubipop/__init__.py
@@ -377,13 +377,19 @@ class UbiPopulateRunner(object):
         return self._determine_pulp_actions(pkgs, current, self._diff_packages_by_filename)
 
     def _get_pulp_actions_src_pkgs(self, pkgs, current):
+        """
+        Get required pulp actions to make sure existing and desired source packages are in
+        match.
+        """
         src_pkgs = {}
         uniq_srpms = {}
+        # filter out packages that share same source rpm
         for _, pkgs in pkgs.items():
             for pkg in pkgs:
                 fn = pkg.filename or pkg.sourcerpm_filename
                 uniq_srpms[fn] = pkg
 
+        # remap uniq srpms to format accepted by _determine_pulp_actions
         for _, srpm in uniq_srpms.items():
             src_pkgs[srpm.name] = [srpm]
 


### PR DESCRIPTION
When making list of srpm packages, there are duplicates in output
list due fact that many rpms can share one srpm. That leads to
unnecessary duplicated associations.
That was fixed in this commit