### PR TITLE
When insecure=True disable SSL warnings logging

### DIFF
--- a/tests/test_pulp.py
+++ b/tests/test_pulp.py
@@ -403,3 +403,8 @@ def test_session_is_not_shared(mock_pulp, count):
         assert isinstance(session, requests.Session)
         assert isinstance(session.get_adapter('http://'), PulpRetryAdapter)
         assert isinstance(session.get_adapter('https://'), PulpRetryAdapter)
+
+def test_insecure():
+    with patch("urllib3.disable_warnings") as patched_warnings:
+        Pulp('foo.host', ('fake', 'user'), insecure=True)
+        patched_warnings.assert_called_once()

--- a/ubipop/_pulp_client.py
+++ b/ubipop/_pulp_client.py
@@ -46,6 +46,10 @@ class Pulp(object):
         self.base_url = urljoin(self.scheme + hostname, self.PULP_API)
         self.insecure = insecure
         self.local = threading.local()
+        if insecure:
+            import urllib3
+            urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+
 
     def _make_session(self):
         adapter = PulpRetryAdapter()


### PR DESCRIPTION
When insecure=True is pass to Pulp client instance it's expected that
ssl certificate can't be verified, therefore it's not neccessary to
keep SSL warning messages enabled.