### PR TITLE
Fix unique filter for srpms

### DIFF
--- a/tests/test_ubipop.py
+++ b/tests/test_ubipop.py
@@ -915,25 +915,29 @@ def test_get_pulp_no_duplicates(mock_ubipop_runner, mock_current_content_ft):
     mock_ubipop_runner.repos.debug_rpms = {"test_debug_pkg": [get_test_pkg(name="debug_rpm_current",
                                                                            filename="debug_rpm_current.rpm")]}
 
-    mock_ubipop_runner.repos.source_rpms = {"test_srpm": [get_test_pkg(name="test_srpm",
-                                                                       filename=
-                                                                       "srpm_current.src.rpm")],
-                                            "test_pkg": [get_test_pkg(name="test_pkg",
-                                                                      filename=
-                                                                      "srpm_new.src.rpm")],
-                                            "foo_pkg": [get_test_pkg(name="foo_pkg",
-                                                                     filename=
-                                                                     "srpm_new.src.rpm")],
-                                            "bar_pkg": [get_test_pkg(name="bar_pkg",
-                                                                     filename=
-                                                                     "srpm_new_next.src.rpm")]}
+    mock_ubipop_runner.repos.source_rpms = {
+        "test_srpm": [
+            get_test_pkg(name="test_srpm",
+                         filename="test_srpm-1.0-1.src.rpm")],
+        "test_srpm2": [
+            get_test_pkg(name="test_srpm",
+                         filename="test_srpm-1.0-2.src.rpm")],
+        "test_srpm3": [
+            get_test_pkg(name="test_srpm",
+                         filename="test_srpm-1.1-1.src.rpm")],
+        "test_pkg": [get_test_pkg(name="test_pkg",
+                                  filename="srpm_new.src.rpm")],
+        "foo_pkg": [get_test_pkg(name="foo_pkg",
+                                 filename="srpm_new.src.rpm")],
+        "bar_pkg": [get_test_pkg(name="bar_pkg",
+                                 filename="srpm_new_next.src.rpm")]}
 
     associations, _, _, _ = \
         mock_ubipop_runner._get_pulp_actions(*mock_current_content_ft) # pylint: disable=W0212
 
     _, _, srpms, _ = associations
-    # only two srpm associations, no duplicates
-    assert len(srpms.units) == 2
+    # only 5 srpm associations, no duplicates
+    assert len(srpms.units) == 5
 
 
 def test_associate_units(mock_ubipop_runner):

--- a/ubipop/__init__.py
+++ b/ubipop/__init__.py
@@ -391,7 +391,7 @@ class UbiPopulateRunner(object):
 
         # remap uniq srpms to format accepted by _determine_pulp_actions
         for _, srpm in uniq_srpms.items():
-            src_pkgs[srpm.name] = [srpm]
+            src_pkgs[(srpm.name, srpm.version, srpm.release)] = [srpm]
 
         return self._determine_pulp_actions(src_pkgs, current, self._diff_packages_by_filename)
 


### PR DESCRIPTION
release and version subkeys were added to srpm unique filter to work
correctly in situations where srpms with same name but different
versions or releases needs to be associated.