### PR TITLE
Only populate repos marked for population

### DIFF
--- a/tests/test_pulp.py
+++ b/tests/test_pulp.py
@@ -40,6 +40,7 @@ def fixture_search_repo_response():
         "notes": {
             "arch": "x86_64",
             "content_set": "test_repo-source-rpms",
+            "platform": "ubi",
             "platform_full_version": "7",
         },
         "distributors": [{
@@ -182,6 +183,8 @@ def test_search_repo_by_cs(mock_pulp, mock_search_repos):
     assert repo.content_set == "test_repo-source-rpms"
     assert repo.platform_full_version == "7"
     assert repo.distributors_ids_type_ids_tuples[0] == ("dist_id", "d_type_id")
+    # ubi_population note was unset, so it should default to True
+    assert repo.ubi_population is True
 
 
 def test_search_repo_by_id(mock_pulp, mock_search_repos):
@@ -195,6 +198,8 @@ def test_search_repo_by_id(mock_pulp, mock_search_repos):
     assert repo.content_set == "test_repo-source-rpms"
     assert repo.platform_full_version == "7"
     assert repo.distributors_ids_type_ids_tuples[0] == ("dist_id", "d_type_id")
+    # ubi_population note was unset, so it should default to True
+    assert repo.ubi_population is True
 
 
 def test_publish_repo(mock_pulp, mock_publish, mock_repo):

--- a/tests/test_pulp.py
+++ b/tests/test_pulp.py
@@ -56,6 +56,7 @@ def fixture_mock_repo():
         arch="x86_64",
         content_set="test_repo-source-rpms",
         platform_full_version="7",
+        ubi_population=None,
         dist_ids_type_ids=[
             ("dist_id_1", "dist_type_id_1"),
             ("dist_id_2", "dist_type_id_2"),

--- a/tests/test_pulp.py
+++ b/tests/test_pulp.py
@@ -57,11 +57,11 @@ def fixture_mock_repo():
         arch="x86_64",
         content_set="test_repo-source-rpms",
         platform_full_version="7",
-        ubi_population=None,
         dist_ids_type_ids=[
             ("dist_id_1", "dist_type_id_1"),
             ("dist_id_2", "dist_type_id_2"),
         ],
+        ubi_population=None,
     )
 
 

--- a/tests/test_ubipop.py
+++ b/tests/test_ubipop.py
@@ -10,7 +10,7 @@ from collections import defaultdict
 import pytest
 import ubiconfig
 
-from mock import MagicMock, patch, call, ANY
+from mock import MagicMock, patch, call
 from more_executors import Executors
 from ubipop import UbiPopulateRunner, UbiRepoSet, RepoSet, UbiPopulate
 from ubipop._pulp_client import Module, ModuleDefaults, Package, Repo

--- a/tests/test_ubipop.py
+++ b/tests/test_ubipop.py
@@ -10,7 +10,7 @@ from collections import defaultdict
 import pytest
 import ubiconfig
 
-from mock import MagicMock, patch, call, ANY
+from mock import MagicMock, patch, call
 from more_executors import Executors
 from ubipop import UbiPopulateRunner, UbiRepoSet, RepoSet, UbiPopulate
 from ubipop._pulp_client import Module, ModuleDefaults, Package, Repo
@@ -180,12 +180,8 @@ def test_skip_outdated_dot_repos(mocked_search_repo_by_cs, mocked_ubipop_runner,
 
     # should've only populated rhel-8-for-x86_64-appstream
     assert mocked_ubipop_runner.call_count == 1
-    golang_config = [c for c in ubipop.ubiconfig_list if str(c) == "ubiconf_golang.yaml"][0]
-    mocked_ubipop_runner.assert_called_with(
-        ubipop.pulp, ANY, golang_config, False, ubipop._executor
-    )
 
-    # should've logged that ubi-7-server repos were skipped
+    # should've skipped ubi-7-server repos
     for message in [
         "Skipping repos not labeled for population:",
         "ubi-7-server-rpms__7_DOT_2__x86_64",

--- a/tests/test_ubipop.py
+++ b/tests/test_ubipop.py
@@ -66,8 +66,8 @@ def get_test_repo(**kwargs):
         kwargs.get('arch'),
         kwargs.get('content_set'),
         kwargs.get('platform_full_version'),
-        kwargs.get('ubi_population'),
         kwargs.get('distributors_ids_type_ids'),
+        kwargs.get('ubi_population'),
     )
 
 
@@ -109,9 +109,9 @@ def test_get_output_repo_ids_no_debug(ubi_repo_set_no_debug):
 @patch("ubipop.UbiPopulateRunner")
 @patch("ubipop._pulp_client.Pulp.search_repo_by_cs")
 def test_skip_outdated_dot_repos(mocked_search_repo_by_cs, mocked_ubipop_runner, caplog):
-    # don't actually query Pulp for repos
+    # Don't actually query Pulp for repos
     mocked_search_repo_by_cs.side_effect = [
-        # input repos - rhel-8-for-x86_64-appstream
+        # Input repos - rhel-8-for-x86_64-appstream
         [get_test_repo(
             repo_id="rhel-8-for-x86_64-appstream-rpms",
             content_set="rhel-8-for-x86_64-appstream-rpms",
@@ -125,7 +125,7 @@ def test_skip_outdated_dot_repos(mocked_search_repo_by_cs, mocked_ubipop_runner,
             content_set="rhel-8-for-x86_64-appstream-debug-rpms",
         ), ],
 
-        # output repos - rhel-8-for-x86_64-appstream
+        # Output repos - rhel-8-for-x86_64-appstream
         [get_test_repo(
             repo_id="ubi-8-for-x86_64-appstream-rpms",
             content_set="ubi-8-for-x86_64-appstream-rpms",
@@ -142,7 +142,7 @@ def test_skip_outdated_dot_repos(mocked_search_repo_by_cs, mocked_ubipop_runner,
             ubi_population=True
         ), ],
 
-        # input repos - rhel-7-server
+        # Input repos - rhel-7-server
         [get_test_repo(
             repo_id="rhel-7-server-rpms__7_DOT_2__x86_64",
             content_set="rhel-7-server-rpms",
@@ -156,7 +156,7 @@ def test_skip_outdated_dot_repos(mocked_search_repo_by_cs, mocked_ubipop_runner,
             content_set="rhel-7-server-debuginfo-rpms",
         ), ],
 
-        # output repos - rhel-7-server
+        # Output repos - rhel-7-server
         [get_test_repo(
             repo_id="ubi-7-server-rpms__7_DOT_2__x86_64",
             content_set="ubi-7-server-rpms",
@@ -174,21 +174,18 @@ def test_skip_outdated_dot_repos(mocked_search_repo_by_cs, mocked_ubipop_runner,
         ), ],
     ]
 
-    # populate both invalid and valid repo sets
+    # Attempt to populate both invalid and valid repo sets
     ubipop = UbiPopulate("foo.pulp.com", ("foo", "foo"), False, ubiconfig_dir_or_url=TEST_DATA_DIR)
     ubipop.populate_ubi_repos()
 
-    # should've only populated rhel-8-for-x86_64-appstream
+    # Should've populated rhel-8-for-x86_64-appstream
     assert mocked_ubipop_runner.call_count == 1
+    msg = "Skipping repo set for rhel-8-for-x86_64-appstream-rpms: should not be populated"
+    assert msg not in caplog.text
 
-    # should've skipped ubi-7-server repos
-    for message in [
-        "Skipping repos not labeled for population:",
-        "ubi-7-server-rpms__7_DOT_2__x86_64",
-        "ubi-7-server-source-rpms__7_DOT_2__x86_64",
-        "ubi-7-server-debuginfo-rpms__7_DOT_2__x86_64"
-    ]:
-        assert message in caplog.text
+    # Should've skipped rhel-7-server repo set
+    msg = "Skipping repo set for rhel-7-server-rpms__7_DOT_2__x86_64: should not be populated"
+    assert msg in caplog.text
 
 
 def test_get_packages_from_module_by_name(mock_ubipop_runner):

--- a/tests/test_ubipop.py
+++ b/tests/test_ubipop.py
@@ -10,7 +10,7 @@ from collections import defaultdict
 import pytest
 import ubiconfig
 
-from mock import MagicMock, patch, call
+from mock import MagicMock, patch, call, ANY
 from more_executors import Executors
 from ubipop import UbiPopulateRunner, UbiRepoSet, RepoSet, UbiPopulate
 from ubipop._pulp_client import Module, ModuleDefaults, Package, Repo
@@ -160,7 +160,7 @@ def test_skip_outdated_dot_repos(mocked_search_repo_by_cs, mocked_ubipop_runner,
         [get_test_repo(
             repo_id="ubi-7-server-rpms__7_DOT_2__x86_64",
             content_set="ubi-7-server-rpms",
-            ubi_population=False
+            ubi_population=True
         ), ],
         [get_test_repo(
             repo_id="ubi-7-server-source-rpms__7_DOT_2__x86_64",
@@ -178,14 +178,12 @@ def test_skip_outdated_dot_repos(mocked_search_repo_by_cs, mocked_ubipop_runner,
     ubipop = UbiPopulate("foo.pulp.com", ("foo", "foo"), False, ubiconfig_dir_or_url=TEST_DATA_DIR)
     ubipop.populate_ubi_repos()
 
-    # Should've populated rhel-8-for-x86_64-appstream
+    # Should've only run once
     assert mocked_ubipop_runner.call_count == 1
-    msg = "Skipping repo set for rhel-8-for-x86_64-appstream-rpms: should not be populated"
-    assert msg not in caplog.text
-
-    # Should've skipped rhel-7-server repo set
-    msg = "Skipping repo set for rhel-7-server-rpms__7_DOT_2__x86_64: should not be populated"
-    assert msg in caplog.text
+    # For rhel-8-for-x86_64-appstream
+    assert "Skipping rhel-8-for-x86_64-appstream" not in caplog.text
+    # Not for rhel-7-server
+    assert "Skipping rhel-7-server-rpms" in caplog.text
 
 
 def test_get_packages_from_module_by_name(mock_ubipop_runner):

--- a/tests/test_ubipop.py
+++ b/tests/test_ubipop.py
@@ -174,9 +174,8 @@ def test_skip_outdated_dot_repos(mocked_search_repo_by_cs, mocked_ubipop_runner,
         ), ],
     ]
 
-    # call populate by content set labels for both invalid and valid repo sets
-    ubipop = UbiPopulate("foo.pulp.com", ("foo", "foo"), False, ubiconfig_dir_or_url=TEST_DATA_DIR,
-                         content_sets=["rhel-7-server-rpms", "rhel-8-for-x86_64-appstream-rpms"])
+    # populate both invalid and valid repo sets
+    ubipop = UbiPopulate("foo.pulp.com", ("foo", "foo"), False, ubiconfig_dir_or_url=TEST_DATA_DIR)
     ubipop.populate_ubi_repos()
 
     # should've only populated rhel-8-for-x86_64-appstream
@@ -189,9 +188,9 @@ def test_skip_outdated_dot_repos(mocked_search_repo_by_cs, mocked_ubipop_runner,
     # should've logged that ubi-7-server repos were skipped
     for message in [
         "Skipping repos not labeled for population:",
-        "ubi-7-server-rpms",
-        "ubi-7-server-source-rpms",
-        "ubi-7-server-debuginfo-rpms"
+        "ubi-7-server-rpms__7_DOT_2__x86_64",
+        "ubi-7-server-source-rpms__7_DOT_2__x86_64",
+        "ubi-7-server-debuginfo-rpms__7_DOT_2__x86_64"
     ]:
         assert message in caplog.text
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -16,15 +16,15 @@ from ubipop._pulp_client import Repo
 
 def test_raise_not_implemented_pulp_action():
     units = ["unit1", "unit2"]
-    repo = Repo("test", "test-rpms", "1", None, "2", None)
+    repo = Repo("test", "1", "test-rpms", "2", None, None)
     action = PulpAction(units, repo)
     pytest.raises(NotImplementedError, action.get_action, None)
 
 
 def test_raise_not_implemented_associate_action():
     units = ["unit1", "unit2"]
-    repo = Repo("test", "test-rpms", "1", None, "2", None)
-    src_repo = Repo("test", "test-rpms", "1", None, "2", None)
+    repo = Repo("test", "1", "test-rpms", "2", None, None)
+    src_repo = Repo("test", "1", "test-rpms", "2", None, None)
     action = AssociateAction(units, repo, src_repo)
     pytest.raises(NotImplementedError, action.get_action, None)
 
@@ -36,8 +36,8 @@ def test_raise_not_implemented_associate_action():
 ])
 def test_get_action_associate(klass, method):
     units = ["unit1", "unit2"]
-    dst_repo = Repo("test_dst", "test_dst-rpms", "1", None, "2", None)
-    src_repo = Repo("test_src", "test_src-rpms", "1", None, "2", None)
+    dst_repo = Repo("test_dst", "1", "test_dst-rpms", "2", None, None)
+    src_repo = Repo("test_src", "1", "test_src-rpms", "2", None, None)
     action = klass(units, dst_repo, src_repo)
     associate_action, src_repo_current, dst_repo_current, current_units = \
         action.get_action(MagicMock())
@@ -55,7 +55,7 @@ def test_get_action_associate(klass, method):
 ])
 def test_get_action_unassociate(klass, method):
     units = ["unit1", "unit2"]
-    dst_repo = Repo("test_dst", "test_dst-rpms", "1", None, "2", None)
+    dst_repo = Repo("test_dst", "1", "test_dst-rpms", "2", None, None)
     action = klass(units, dst_repo)
     associate_action, dst_repo_current, current_units = action.get_action(MagicMock())
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -16,15 +16,15 @@ from ubipop._pulp_client import Repo
 
 def test_raise_not_implemented_pulp_action():
     units = ["unit1", "unit2"]
-    repo = Repo("test", "test-rpms", "1", "2", None)
+    repo = Repo("test", "test-rpms", "1", None, "2", None)
     action = PulpAction(units, repo)
     pytest.raises(NotImplementedError, action.get_action, None)
 
 
 def test_raise_not_implemented_associate_action():
     units = ["unit1", "unit2"]
-    repo = Repo("test", "test-rpms", "1", "2", None)
-    src_repo = Repo("test", "test-rpms", "1", "2", None)
+    repo = Repo("test", "test-rpms", "1", None, "2", None)
+    src_repo = Repo("test", "test-rpms", "1", None, "2", None)
     action = AssociateAction(units, repo, src_repo)
     pytest.raises(NotImplementedError, action.get_action, None)
 
@@ -36,8 +36,8 @@ def test_raise_not_implemented_associate_action():
 ])
 def test_get_action_associate(klass, method):
     units = ["unit1", "unit2"]
-    dst_repo = Repo("test_dst", "test_dst-rpms", "1", "2", None)
-    src_repo = Repo("test_src", "test_src-rpms", "1", "2", None)
+    dst_repo = Repo("test_dst", "test_dst-rpms", "1", None, "2", None)
+    src_repo = Repo("test_src", "test_src-rpms", "1", None, "2", None)
     action = klass(units, dst_repo, src_repo)
     associate_action, src_repo_current, dst_repo_current, current_units = \
         action.get_action(MagicMock())
@@ -55,7 +55,7 @@ def test_get_action_associate(klass, method):
 ])
 def test_get_action_unassociate(klass, method):
     units = ["unit1", "unit2"]
-    dst_repo = Repo("test_dst", "test_dst-rpms", "1", "2", None)
+    dst_repo = Repo("test_dst", "test_dst-rpms", "1", None, "2", None)
     action = klass(units, dst_repo)
     associate_action, dst_repo_current, current_units = action.get_action(MagicMock())
 

--- a/ubipop/__init__.py
+++ b/ubipop/__init__.py
@@ -193,7 +193,7 @@ class UbiPopulate(object):
             no_populate = [r for r in (out_rpm, out_source, out_debug_info) if not r.ubi_population]
             if no_populate:
                 _LOG.debug("Skipping repos not labeled for population:\n\t%s",
-                           "\n\t".join(r.content_set for r in no_populate))
+                           "\n\t".join(r.repo_id for r in no_populate))
                 continue
 
             rhel_repo_set = RepoSet(in_rpm, in_source, in_debug_info)

--- a/ubipop/__init__.py
+++ b/ubipop/__init__.py
@@ -189,20 +189,15 @@ class UbiPopulate(object):
             out_source = self._get_repo_counterpart(input_repo, out_source_repos_ft.result())
             out_debug_info = self._get_repo_counterpart(input_repo, out_debug_repos_ft.result())
 
-            # identify any ubi repos not marked for population
-            no_populate = []
-            for repo in (out_rpm, out_source, out_debug_info):
-                if repo.ubi_population is False:
-                    no_populate.append(repo)
+            # skip repo set if not all output repos are intended for population
+            can_pop = [r for r in (out_rpm, out_source, out_debug_info) if r.ubi_population is True]
+            if len(can_pop) == 3:
+                rhel_repo_set = RepoSet(in_rpm, in_source, in_debug_info)
+                ubi_repo_set = RepoSet(out_rpm, out_source, out_debug_info)
+                repo_pairs.append(UbiRepoSet(rhel_repo_set, ubi_repo_set))
 
-            if no_populate:
-                _LOG.debug("Skipping repos not labeled for population:\n\t%s",
-                           "\n\t".join(r.repo_id for r in no_populate))
-                continue
-
-            rhel_repo_set = RepoSet(in_rpm, in_source, in_debug_info)
-            ubi_repo_set = RepoSet(out_rpm, out_source, out_debug_info)
-            repo_pairs.append(UbiRepoSet(rhel_repo_set, ubi_repo_set))
+            _LOG.debug("Skipping repos not labeled for population:\n\t%s", "\n\t".join(
+                [r.repo_id for r in (out_rpm, out_source, out_debug_info) if r not in can_pop]))
 
         return repo_pairs
 

--- a/ubipop/__init__.py
+++ b/ubipop/__init__.py
@@ -189,14 +189,18 @@ class UbiPopulate(object):
             out_source = self._get_repo_counterpart(input_repo, out_source_repos_ft.result())
             out_debug_info = self._get_repo_counterpart(input_repo, out_debug_repos_ft.result())
 
+            in_repos = (in_rpm, in_source, in_debug_info)
+            out_repos = (out_rpm, out_source, out_debug_info)
+
             # Skip repos sets containing output repos which should not be populated
-            if not all([r.ubi_population is True for r in (out_rpm, out_source, out_debug_info)]):
-                _LOG.debug("Skipping repo set for %s: should not be populated", in_rpm.repo_id)
+            if not all([r.ubi_population is True for r in out_repos]):
+                _LOG.debug(
+                    "Skipping %s, population disabled for output repo(s):\n\t%s",
+                    in_rpm.content_set,
+                    "\n\t".join(r.content_set for r in out_repos if r.ubi_population is False))
                 continue
 
-            rhel_repo_set = RepoSet(in_rpm, in_source, in_debug_info)
-            ubi_repo_set = RepoSet(out_rpm, out_source, out_debug_info)
-            repo_pairs.append(UbiRepoSet(rhel_repo_set, ubi_repo_set))
+            repo_pairs.append(UbiRepoSet(RepoSet(*in_repos), RepoSet(*out_repos)))
 
         return repo_pairs
 

--- a/ubipop/__init__.py
+++ b/ubipop/__init__.py
@@ -190,7 +190,11 @@ class UbiPopulate(object):
             out_debug_info = self._get_repo_counterpart(input_repo, out_debug_repos_ft.result())
 
             # identify any ubi repos not marked for population
-            no_populate = [r for r in (out_rpm, out_source, out_debug_info) if not r.ubi_population]
+            no_populate = []
+            for repo in (out_rpm, out_source, out_debug_info):
+                if repo.ubi_population is False:
+                    no_populate.append(repo)
+
             if no_populate:
                 _LOG.debug("Skipping repos not labeled for population:\n\t%s",
                            "\n\t".join(r.repo_id for r in no_populate))

--- a/ubipop/__init__.py
+++ b/ubipop/__init__.py
@@ -189,15 +189,17 @@ class UbiPopulate(object):
             out_source = self._get_repo_counterpart(input_repo, out_source_repos_ft.result())
             out_debug_info = self._get_repo_counterpart(input_repo, out_debug_repos_ft.result())
 
-            # skip repo set if not all output repos are intended for population
-            can_pop = [r for r in (out_rpm, out_source, out_debug_info) if r.ubi_population is True]
-            if len(can_pop) == 3:
-                rhel_repo_set = RepoSet(in_rpm, in_source, in_debug_info)
-                ubi_repo_set = RepoSet(out_rpm, out_source, out_debug_info)
-                repo_pairs.append(UbiRepoSet(rhel_repo_set, ubi_repo_set))
+            # Only create repo set if *all* output repos are intended for population
+            # We can trust that repos which are not have this set to False
+            no_pop = [r for r in (out_rpm, out_source, out_debug_info) if r.ubi_population is False]
+            if no_pop:
+                _LOG.debug("Skipping repos not labeled for population:\n\t%s",
+                           "\n\t".join([r.repo_id for r in no_pop]))
+                continue
 
-            _LOG.debug("Skipping repos not labeled for population:\n\t%s", "\n\t".join(
-                [r.repo_id for r in (out_rpm, out_source, out_debug_info) if r not in can_pop]))
+            rhel_repo_set = RepoSet(in_rpm, in_source, in_debug_info)
+            ubi_repo_set = RepoSet(out_rpm, out_source, out_debug_info)
+            repo_pairs.append(UbiRepoSet(rhel_repo_set, ubi_repo_set))
 
         return repo_pairs
 

--- a/ubipop/__init__.py
+++ b/ubipop/__init__.py
@@ -189,12 +189,9 @@ class UbiPopulate(object):
             out_source = self._get_repo_counterpart(input_repo, out_source_repos_ft.result())
             out_debug_info = self._get_repo_counterpart(input_repo, out_debug_repos_ft.result())
 
-            # Only create repo set if *all* output repos are intended for population
-            # We can trust that repos which are not have this set to False
-            no_pop = [r for r in (out_rpm, out_source, out_debug_info) if r.ubi_population is False]
-            if no_pop:
-                _LOG.debug("Skipping repos not labeled for population:\n\t%s",
-                           "\n\t".join([r.repo_id for r in no_pop]))
+            # Skip repos sets containing output repos which should not be populated
+            if not all([r.ubi_population is True for r in (out_rpm, out_source, out_debug_info)]):
+                _LOG.debug("Skipping repo set for %s: should not be populated", in_rpm.repo_id)
                 continue
 
             rhel_repo_set = RepoSet(in_rpm, in_source, in_debug_info)

--- a/ubipop/_pulp_client.py
+++ b/ubipop/_pulp_client.py
@@ -92,6 +92,7 @@ class Pulp(object):
                 arch=notes['arch'],
                 content_set=notes['content_set'],
                 platform_full_version=notes['platform_full_version'],
+                ubi_population=notes.get('ubi_population', None),  # ubi repos only
                 dist_ids_type_ids=dist_info,
             ))
 
@@ -306,11 +307,13 @@ class Pulp(object):
 
 
 class Repo(object):
-    def __init__(self, repo_id, arch, content_set, platform_full_version, dist_ids_type_ids):
+    def __init__(self, repo_id, arch, content_set, platform_full_version, ubi_population,
+                 dist_ids_type_ids):
         self.repo_id = repo_id
         self.arch = arch
         self.content_set = content_set
         self.platform_full_version = platform_full_version
+        self.ubi_population = ubi_population
         self.distributors_ids_type_ids_tuples = dist_ids_type_ids
 
 

--- a/ubipop/_pulp_client.py
+++ b/ubipop/_pulp_client.py
@@ -89,14 +89,14 @@ class Pulp(object):
             dist_info = [(dist['id'], dist['distributor_type_id']) for dist in item['distributors']]
             # Only UBI repos should have a ubi_population note, set to None for other platforms
             # If the UBI repo does not have this note, assume it is okay to populate
-            ubi_populate = notes.get('ubi_populate', True) if notes['platform'] == 'ubi' else None
+            ubi_population = notes.get('ubi_population', True) if notes['platform'] == 'ubi' else None
             repos.append(Repo(
                 repo_id=item['id'],
                 arch=notes['arch'],
                 content_set=notes['content_set'],
                 platform_full_version=notes['platform_full_version'],
                 dist_ids_type_ids=dist_info,
-                ubi_population=ubi_populate,
+                ubi_population=ubi_population,
             ))
 
         return repos

--- a/ubipop/_pulp_client.py
+++ b/ubipop/_pulp_client.py
@@ -317,9 +317,7 @@ class Repo(object):
         self.content_set = content_set
         self.platform_full_version = platform_full_version
         self.distributors_ids_type_ids_tuples = dist_ids_type_ids
-        # Only assign ubi_population for UBI repos
-        if ubi_population is not None:
-            self.ubi_population = ubi_population
+        self.ubi_population = ubi_population
 
 
 class Package(object):


### PR DESCRIPTION
Using the new repo note, ubi_population, this commit ensures repo sets
that would contain repos not intended for population are skipped.

Fixes #92