### PR TITLE
Revert "Conditional creation of install_requires of rpm distribution …

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 requests
 more-executors
 ubi-config
+rpm-py-installer

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,4 @@
 from setuptools import setup
-import pkg_resources
 
 
 def get_description():
@@ -15,24 +14,9 @@ def get_long_description():
     return text[idx:]
 
 
-def get_rpm_distribution():
-    for distribution in ['rpm', 'rpm-python']:
-        try:
-            pkg_resources.get_distribution(distribution)
-        except pkg_resources.DistributionNotFound:
-            continue
-        else:
-            return distribution
-    return 'rpm-py-installer'
-
-
 def get_requirements():
-    requirements = [get_rpm_distribution()]
-
     with open('requirements.txt') as f:
-        requirements.extend(f.read().splitlines())
-
-    return requirements
+        return f.read().splitlines()
 
 
 setup(name='ubi-population-tool',


### PR DESCRIPTION
…(#114)"

Reverting this commit as it doesn't help with RPM build of this
project. This change is followed by another change in specfile
that manually removes rpm-py-installer from requirements.txt 
per recommendation in https://github.com/junaruga/rpm-py-installer/blob/master/docs/users_guide.md  (Q6)


See related DELIVERY-7245.

This reverts commit c8731e11e3de0dd53fef432b2c801e6bacab7315.