### PR TITLE
Supp population sources

### DIFF
--- a/tests/test_pulp.py
+++ b/tests/test_pulp.py
@@ -43,6 +43,7 @@ def fixture_search_repo_response():
             "content_set": "test_repo-source-rpms",
             "platform": "ubi",
             "platform_full_version": "7",
+
         },
         "distributors": [{
             "id": "dist_id",
@@ -63,17 +64,18 @@ def fixture_mock_repo():
             ("dist_id_2", "dist_type_id_2"),
         ],
         ubi_population=None,
+        population_sources=None
     )
 
 
 @pytest.fixture(name='mock_package')
 def fixture_mock_package():
-    yield Package("foo-pkg", "foo-pkg.rpm")
+    yield Package("foo-pkg", "foo-pkg.rpm", "src_repo_id")
 
 
 @pytest.fixture(name='mock_mdd')
 def fixture_mock_mdd():
-    yield ModuleDefaults("virt", "rhel", {"2.6": ["common"]})
+    yield ModuleDefaults("virt", "rhel", {"2.6": ["common"]}, "src_repo_id")
 
 
 @pytest.fixture(name='mock_response_for_async_req')

--- a/tests/test_pulp.py
+++ b/tests/test_pulp.py
@@ -43,7 +43,6 @@ def fixture_search_repo_response():
             "content_set": "test_repo-source-rpms",
             "platform": "ubi",
             "platform_full_version": "7",
-
         },
         "distributors": [{
             "id": "dist_id",

--- a/tests/test_ubipop.py
+++ b/tests/test_ubipop.py
@@ -212,7 +212,7 @@ def test_get_population_sources_repo_note(mocked_search_repo_by_id):
                                                           )
                                              ],
                                             ]
-    repos = ubipop._get_population_sources(repo, None)
+    repos = ubipop._get_population_sources(repo, None)  # pylint: disable=protected-access
     assert len(repos) == 2
 
 
@@ -228,7 +228,7 @@ def test_get_population_sources_by_search(search_repo_by_cs):
                                                     )
                                       ],
                                      ]
-    repos = ubipop._get_population_sources(repo, None)
+    repos = ubipop._get_population_sources(repo, None)  # pylint: disable=protected-access
     assert len(repos) == 1
 
 

--- a/tests/test_ubipop.py
+++ b/tests/test_ubipop.py
@@ -27,9 +27,9 @@ TEST_DATA_DIR = os.path.join(os.path.dirname(__file__), './data')
 
 @pytest.fixture(name='ubi_repo_set')
 def fixture_ubi_repo_set():
-    yield UbiRepoSet(RepoSet(get_test_repo(repo_id="foo-rpms"),
-                             get_test_repo(repo_id="foo-source"),
-                             get_test_repo(repo_id="foo-debug")),
+    yield UbiRepoSet(RepoSet([get_test_repo(repo_id="foo-rpms")],
+                             [get_test_repo(repo_id="foo-source")],
+                             [get_test_repo(repo_id="foo-debug")]),
                      RepoSet(get_test_repo(repo_id="ubi-foo-rpms"),
                              get_test_repo(repo_id="ubi-foo-source"),
                              get_test_repo(repo_id="ubi-foo-debug")))
@@ -37,8 +37,8 @@ def fixture_ubi_repo_set():
 
 @pytest.fixture(name='ubi_repo_set_no_debug')
 def fixture_ubi_repo_set_no_debug():
-    yield UbiRepoSet(RepoSet(get_test_repo(repo_id="foo-rpms"),
-                             get_test_repo(repo_id="foo-source"),
+    yield UbiRepoSet(RepoSet([get_test_repo(repo_id="foo-rpms")],
+                             [get_test_repo(repo_id="foo-source")],
                              None),
                      RepoSet(get_test_repo(repo_id="ubi-foo-rpms"),
                              get_test_repo(repo_id="ubi-foo-source"),
@@ -68,6 +68,7 @@ def get_test_repo(**kwargs):
         kwargs.get('platform_full_version'),
         kwargs.get('distributors_ids_type_ids'),
         kwargs.get('ubi_population'),
+        kwargs.get('population_sources'),
     )
 
 
@@ -75,6 +76,7 @@ def get_test_pkg(**kwargs):
     return Package(
         kwargs.get('name'),
         kwargs.get('filename'),
+        kwargs.get('src_repo_id'),
         sourcerpm_filename=kwargs.get('sourcerpm_filename'),
         is_modular=kwargs.get('is_modular', False),
     )
@@ -89,11 +91,16 @@ def get_test_mod(**kwargs):
         kwargs.get('arch', ''),
         kwargs.get('packages', ''),
         kwargs.get('profiles', ''),
+        kwargs.get('src_repo_id'),
     )
 
 
 def get_test_mod_defaults(**kwargs):
-    return ModuleDefaults(kwargs['name'], kwargs['stream'], kwargs['profiles'])
+    return ModuleDefaults(kwargs['name'],
+                          kwargs['stream'],
+                          kwargs['profiles'],
+                          kwargs.get('src_repo_id'),
+                         )
 
 
 def test_get_output_repo_ids(ubi_repo_set):
@@ -111,20 +118,6 @@ def test_get_output_repo_ids_no_debug(ubi_repo_set_no_debug):
 def test_skip_outdated_dot_repos(mocked_search_repo_by_cs, mocked_ubipop_runner, caplog):
     # Don't actually query Pulp for repos
     mocked_search_repo_by_cs.side_effect = [
-        # Input repos - rhel-8-for-x86_64-appstream
-        [get_test_repo(
-            repo_id="rhel-8-for-x86_64-appstream-rpms",
-            content_set="rhel-8-for-x86_64-appstream-rpms",
-        ), ],
-        [get_test_repo(
-            repo_id="rhel-8-for-x86_64-appstream-source-rpms",
-            content_set="rhel-8-for-x86_64-appstream-source-rpms",
-        ), ],
-        [get_test_repo(
-            repo_id="rhel-8-for-x86_64-appstream-debug-rpms",
-            content_set="rhel-8-for-x86_64-appstream-debug-rpms",
-        ), ],
-
         # Output repos - rhel-8-for-x86_64-appstream
         [get_test_repo(
             repo_id="ubi-8-for-x86_64-appstream-rpms",
@@ -142,6 +135,39 @@ def test_skip_outdated_dot_repos(mocked_search_repo_by_cs, mocked_ubipop_runner,
             ubi_population=True
         ), ],
 
+        # Input repos - rhel-8-for-x86_64-appstream
+        [get_test_repo(
+            repo_id="rhel-8-for-x86_64-appstream-rpms",
+            content_set="rhel-8-for-x86_64-appstream-rpms",
+        ), ],
+        [get_test_repo(
+            repo_id="rhel-8-for-x86_64-appstream-source-rpms",
+            content_set="rhel-8-for-x86_64-appstream-source-rpms",
+        ), ],
+        [get_test_repo(
+            repo_id="rhel-8-for-x86_64-appstream-debug-rpms",
+            content_set="rhel-8-for-x86_64-appstream-debug-rpms",
+        ), ],
+
+        # Output repos - rhel-7-server
+        [get_test_repo(
+            repo_id="ubi-7-server-rpms__7_DOT_2__x86_64",
+            content_set="ubi-7-server-rpms",
+            ubi_population=False
+        ), ],
+        [get_test_repo(
+            repo_id="ubi-7-server-source-rpms__7_DOT_2__x86_64",
+            content_set="ubi-7-server-source-rpms",
+            ubi_population=True
+            # doesn't matter here, it sufficient to have ubi_population==False at rpm binary repo
+            # for skipping whole repo triplet
+        ), ],
+        [get_test_repo(
+            repo_id="ubi-7-server-debuginfo-rpms__7_DOT_2__x86_64",
+            content_set="ubi-7-server-debuginfo-rpms",
+            ubi_population=False
+        ), ],
+
         # Input repos - rhel-7-server
         [get_test_repo(
             repo_id="rhel-7-server-rpms__7_DOT_2__x86_64",
@@ -155,23 +181,6 @@ def test_skip_outdated_dot_repos(mocked_search_repo_by_cs, mocked_ubipop_runner,
             repo_id="rhel-7-server-debuginfo-rpms__7_DOT_2__x86_64",
             content_set="rhel-7-server-debuginfo-rpms",
         ), ],
-
-        # Output repos - rhel-7-server
-        [get_test_repo(
-            repo_id="ubi-7-server-rpms__7_DOT_2__x86_64",
-            content_set="ubi-7-server-rpms",
-            ubi_population=True
-        ), ],
-        [get_test_repo(
-            repo_id="ubi-7-server-source-rpms__7_DOT_2__x86_64",
-            content_set="ubi-7-server-source-rpms",
-            ubi_population=False
-        ), ],
-        [get_test_repo(
-            repo_id="ubi-7-server-debuginfo-rpms__7_DOT_2__x86_64",
-            content_set="ubi-7-server-debuginfo-rpms",
-            ubi_population=False
-        ), ],
     ]
 
     # Attempt to populate both invalid and valid repo sets
@@ -180,10 +189,10 @@ def test_skip_outdated_dot_repos(mocked_search_repo_by_cs, mocked_ubipop_runner,
 
     # Should've only run once
     assert mocked_ubipop_runner.call_count == 1
-    # For rhel-8-for-x86_64-appstream
-    assert "Skipping rhel-8-for-x86_64-appstream" not in caplog.text
-    # Not for rhel-7-server
-    assert "Skipping rhel-7-server-rpms" in caplog.text
+    # For ubi-8
+    assert "ubi-8-for-x86_64-appstream-rpms" not in caplog.text
+    # Not for ubi-7-server
+    assert "ubi-7-server-rpms__7_DOT_2__x86_64" in caplog.text
 
 
 def test_get_packages_from_module_by_name(mock_ubipop_runner):
@@ -776,12 +785,14 @@ def test_create_srpms_output_set(mock_ubipop_runner):
             name="tomcatjss",
             filename="tomcatjss-7.3.6-1.el8+1944+b6c8e16f.noarch.rpm",
             sourcerpm_filename="tomcatjss-7.3.6-1.el8+1944+b6c8e16f.src.rpm",
+            src_repo_id="foo-rpms",
         ),
         # blacklisted
         get_test_pkg(
             name="kernel",
             filename="kernel-7.3.6-1.el8+1944+b6c8e16f.noarch.rpm",
             sourcerpm_filename="kernel.src.rpm",
+            src_repo_id="foo-rpms",
         ),
         # blacklisted but referenced in some module
         get_test_pkg(
@@ -789,6 +800,7 @@ def test_create_srpms_output_set(mock_ubipop_runner):
             filename="foo-pkg-7.3.6-1.el8+1944+b6c8e16f.noarch.rpm",
             sourcerpm_filename="foo-pkg-7.3.6-1.el8+1944+b6c8e16f.src.rpm",
             is_modular=True,
+            src_repo_id="foo-rpms",
         ),
     ]
 
@@ -822,9 +834,9 @@ def test_create_srpms_output_set_missings_srpm_reference(capsys, set_logging, mo
 
 @pytest.fixture(name='mock_get_repo_pairs')
 def fixture_mock_get_repo_pairs(ubi_repo_set):
-    with patch('ubipop.UbiPopulate._get_input_and_output_repo_pairs') as get_repo_pairs:
-        get_repo_pairs.return_value = [ubi_repo_set]
-        yield get_repo_pairs
+    with patch('ubipop.UbiPopulate._get_ubi_repo_sets') as get_ubi_repo_sets:
+        get_ubi_repo_sets.return_value = [ubi_repo_set]
+        yield get_ubi_repo_sets
 
 
 @pytest.fixture(name='mock_run_ubi_population')
@@ -914,22 +926,26 @@ def test_get_pulp_actions(mock_ubipop_runner, mock_current_content_ft):
     assert len(modules.units) == 1
     assert modules.units[0].name == "test_md"
     assert modules.dst_repo.repo_id == "ubi-foo-rpms"
-    assert modules.src_repo.repo_id == "foo-rpms"
+    assert len(modules.src_repos) == 1
+    assert modules.src_repos[0].repo_id == "foo-rpms"
 
     assert len(rpms.units) == 1
     assert rpms.units[0].name == "test_rpm"
     assert rpms.dst_repo.repo_id == "ubi-foo-rpms"
-    assert rpms.src_repo.repo_id == "foo-rpms"
+    assert len(rpms.src_repos) == 1
+    assert rpms.src_repos[0].repo_id == "foo-rpms"
 
     assert len(srpms.units) == 1
     assert srpms.units[0].name == "test_srpm"
     assert srpms.dst_repo.repo_id == "ubi-foo-source"
-    assert srpms.src_repo.repo_id == "foo-source"
+    assert len(srpms.src_repos) == 1
+    assert srpms.src_repos[0].repo_id == "foo-source"
 
     assert len(debug_rpms.units) == 1
     assert debug_rpms.units[0].name == "test_debug_pkg"
     assert debug_rpms.dst_repo.repo_id == "ubi-foo-debug"
-    assert debug_rpms.src_repo.repo_id == "foo-debug"
+    assert len(debug_rpms.src_repos) == 1
+    assert debug_rpms.src_repos[0].repo_id == "foo-debug"
 
     # secondly, check correct unassociations, there should 1 unit of each type unassociated
     modules, rpms, srpms, debug_rpms = unassociations
@@ -951,12 +967,12 @@ def test_get_pulp_actions(mock_ubipop_runner, mock_current_content_ft):
 
     assert len(mdd_association.units) == 1
     assert mdd_association.dst_repo.repo_id == 'ubi-foo-rpms'
-    assert mdd_association.src_repo.repo_id == 'foo-rpms'
+    assert len(mdd_association.src_repos) == 1
+    assert mdd_association.src_repos[0].repo_id == 'foo-rpms'
 
     assert len(mdd_unassociation.units) == 1
     assert mdd_unassociation.units[0].name == 'mdd_current'
     assert mdd_unassociation.dst_repo.repo_id == 'ubi-foo-rpms'
-
 
 
 def test_get_pulp_actions_no_actions(mock_ubipop_runner, mock_current_content_ft):
@@ -1018,7 +1034,9 @@ def test_log_pulp_action(capsys, set_logging, mock_ubipop_runner):
     set_logging.addHandler(logging.StreamHandler(sys.stdout))
     src_repo = get_test_repo(repo_id='test_src')
     dst_repo = get_test_repo(repo_id='test_dst')
-    associations = [AssociateActionModules([get_test_mod(name="test_assoc")], dst_repo, src_repo)]
+    associations = [AssociateActionModules([get_test_mod(name="test_assoc",
+                                                         src_repo_id=src_repo.repo_id)],
+                                           dst_repo, [src_repo])]
     unassociations = [UnassociateActionModules([get_test_mod(name="test_unassoc")], dst_repo)]
 
     mock_ubipop_runner.log_pulp_actions(associations, unassociations)
@@ -1034,7 +1052,7 @@ def test_log_pulp_action_no_actions(capsys, set_logging, mock_ubipop_runner):
     set_logging.addHandler(logging.StreamHandler(sys.stdout))
     src_repo = get_test_repo(repo_id='test_src')
     dst_repo = get_test_repo(repo_id='test_dst')
-    associations = [AssociateActionModules([], dst_repo, src_repo)]
+    associations = [AssociateActionModules([], dst_repo, [src_repo])]
     unassociations = [UnassociateActionModules([], dst_repo)]
 
     mock_ubipop_runner.log_pulp_actions(associations, unassociations)
@@ -1042,7 +1060,7 @@ def test_log_pulp_action_no_actions(capsys, set_logging, mock_ubipop_runner):
     assoc_line, unassoc_line = out.split('\n', 1)
 
     assert err == ""
-    assert assoc_line.strip() == "No association expected for modules from test_src to test_dst"
+    assert assoc_line.strip() == "No association expected for modules from ['test_src'] to test_dst"
     assert unassoc_line.strip() == "No unassociation expected for modules from test_dst"
 
 
@@ -1088,7 +1106,7 @@ def test_associate_units(mock_ubipop_runner):
     dst_repo = get_test_repo(repo_id='test_dst')
 
     associations = [
-        AssociateActionModules([get_test_mod(name="test_assoc")], dst_repo, src_repo),
+        AssociateActionModules([get_test_mod(name="test_assoc")], dst_repo, [src_repo]),
     ]
 
     mock_ubipop_runner.pulp.associate_modules.return_value = ["task_id"]
@@ -1108,7 +1126,7 @@ def test_associate_unassociate_md_defaults(mock_ubipop_runner):
             stream='rhel',
             profiles={'2.5': ["common"]},
         ),
-    ], dst_repo, src_repo)
+    ], dst_repo, [src_repo])
 
     unassociations = UnassociateActionModuleDefaults([
         get_test_mod_defaults(

--- a/tests/test_ubipop.py
+++ b/tests/test_ubipop.py
@@ -195,6 +195,43 @@ def test_skip_outdated_dot_repos(mocked_search_repo_by_cs, mocked_ubipop_runner,
     assert "ubi-7-server-rpms__7_DOT_2__x86_64" in caplog.text
 
 
+@patch("ubipop._pulp_client.Pulp.search_repo_by_id")
+def test_get_population_sources_repo_note(mocked_search_repo_by_id):
+    repo = get_test_repo(
+        repo_id="rhel-8-for-x86_64-appstream-rpms",
+        content_set="rhel-8-for-x86_64-appstream-rpms",
+        population_sources=['src_1', 'src_2']
+    )
+    ubipop = UbiPopulate("foo.pulp.com", ("foo", "foo"), False, ubiconfig_dir_or_url=TEST_DATA_DIR)
+    mocked_search_repo_by_id.side_effect = [[get_test_repo(repo_id="src_1",
+                                                           content_set="src_1_cs",
+                                                          )
+                                             ],
+                                            [get_test_repo(repo_id="src_2",
+                                                           content_set="src_2_cs",
+                                                          )
+                                             ],
+                                            ]
+    repos = ubipop._get_population_sources(repo, None)
+    assert len(repos) == 2
+
+
+@patch("ubipop._pulp_client.Pulp.search_repo_by_cs")
+def test_get_population_sources_by_search(search_repo_by_cs):
+    repo = get_test_repo(
+        repo_id="rhel-8-for-x86_64-appstream-rpms",
+        content_set="rhel-8-for-x86_64-appstream-rpms",
+    )
+    ubipop = UbiPopulate("foo.pulp.com", ("foo", "foo"), False, ubiconfig_dir_or_url=TEST_DATA_DIR)
+    search_repo_by_cs.side_effect = [[get_test_repo(repo_id="src_1",
+                                                    content_set="src_1_cs",
+                                                    )
+                                      ],
+                                     ]
+    repos = ubipop._get_population_sources(repo, None)
+    assert len(repos) == 1
+
+
 def test_get_packages_from_module_by_name(mock_ubipop_runner):
     package_name = "postgresql"
     input_modules = [

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -46,7 +46,7 @@ def test_get_action_associate(klass, method):
     action = klass(units, dst_repo, src_repos)
     actions = action.get_actions(MagicMock())
 
-    for i, action in enumerate(actions):
+    for action in actions:
         associate_action, src_repo_current, dst_repo_current, current_units = action
         assert "mock." + method in str(associate_action)
         assert len(current_units) == 1

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -16,17 +16,17 @@ from ubipop._pulp_client import Repo
 
 def test_raise_not_implemented_pulp_action():
     units = ["unit1", "unit2"]
-    repo = Repo("test", "1", "test-rpms", "2", None, None)
+    repo = Repo("test", "1", "test-rpms", "2", None, None, None)
     action = PulpAction(units, repo)
-    pytest.raises(NotImplementedError, action.get_action, None)
+    pytest.raises(NotImplementedError, action.get_actions, None)
 
 
 def test_raise_not_implemented_associate_action():
     units = ["unit1", "unit2"]
-    repo = Repo("test", "1", "test-rpms", "2", None, None)
-    src_repo = Repo("test", "1", "test-rpms", "2", None, None)
+    repo = Repo("test", "1", "test-rpms", "2", None, None, None)
+    src_repo = Repo("test", "1", "test-rpms", "2", None, None, None)
     action = AssociateAction(units, repo, src_repo)
-    pytest.raises(NotImplementedError, action.get_action, None)
+    pytest.raises(NotImplementedError, action.get_actions, None)
 
 
 @pytest.mark.parametrize("klass, method", [
@@ -35,17 +35,23 @@ def test_raise_not_implemented_associate_action():
     (AssociateActionRpms, "associate_packages"),
 ])
 def test_get_action_associate(klass, method):
-    units = ["unit1", "unit2"]
-    dst_repo = Repo("test_dst", "1", "test_dst-rpms", "2", None, None)
-    src_repo = Repo("test_src", "1", "test_src-rpms", "2", None, None)
-    action = klass(units, dst_repo, src_repo)
-    associate_action, src_repo_current, dst_repo_current, current_units = \
-        action.get_action(MagicMock())
+    mocked_unit_1 = MagicMock()
+    mocked_unit_1.associate_source_repo_id = "test_src_1"
+    mocked_unit_2 = MagicMock()
+    mocked_unit_2.associate_source_repo_id = "test_src_2"
+    units = [mocked_unit_1, mocked_unit_2]
+    dst_repo = Repo("test_dst", "1", "test_dst-rpms", "2", None, None, None)
+    src_repos = [Repo("test_src_1", "1", "test_src-rpms", "2", None, None, None),
+                 Repo("test_src_2", "1", "test_src-rpms", "2", None, None, None)]
+    action = klass(units, dst_repo, src_repos)
+    actions = action.get_actions(MagicMock())
 
-    assert "mock." + method in str(associate_action)
-    assert current_units == units
-    assert dst_repo_current.repo_id == dst_repo.repo_id
-    assert src_repo_current.repo_id == src_repo.repo_id
+    for i, action in enumerate(actions):
+        associate_action, src_repo_current, dst_repo_current, current_units = action
+        assert "mock." + method in str(associate_action)
+        assert current_units == [units[i]]
+        assert dst_repo_current.repo_id == dst_repo.repo_id
+        assert src_repo_current.repo_id == src_repos[i].repo_id
 
 
 @pytest.mark.parametrize("klass, method", [
@@ -55,9 +61,9 @@ def test_get_action_associate(klass, method):
 ])
 def test_get_action_unassociate(klass, method):
     units = ["unit1", "unit2"]
-    dst_repo = Repo("test_dst", "1", "test_dst-rpms", "2", None, None)
+    dst_repo = Repo("test_dst", "1", "test_dst-rpms", "2", None, None, None)
     action = klass(units, dst_repo)
-    associate_action, dst_repo_current, current_units = action.get_action(MagicMock())
+    associate_action, dst_repo_current, current_units = action.get_actions(MagicMock())[0]
 
     assert "mock." + method in str(associate_action)
     assert current_units == units

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -49,7 +49,9 @@ def test_get_action_associate(klass, method):
     for i, action in enumerate(actions):
         associate_action, src_repo_current, dst_repo_current, current_units = action
         assert "mock." + method in str(associate_action)
-        assert current_units == [units[i]]
+
+        assert sorted(current_units) == [u for u in units
+                                         if u.associate_source_repo_id == src_repo_current.repo_id]
         assert dst_repo_current.repo_id == dst_repo.repo_id
         assert src_repo_current.repo_id == src_repos[i].repo_id
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -49,11 +49,11 @@ def test_get_action_associate(klass, method):
     for i, action in enumerate(actions):
         associate_action, src_repo_current, dst_repo_current, current_units = action
         assert "mock." + method in str(associate_action)
-
-        assert sorted(current_units) == [u for u in units
-                                         if u.associate_source_repo_id == src_repo_current.repo_id]
+        assert len(current_units) == 1
+        assert current_units == [u for u in units
+                                 if u.associate_source_repo_id == src_repo_current.repo_id]
         assert dst_repo_current.repo_id == dst_repo.repo_id
-        assert src_repo_current.repo_id == src_repos[i].repo_id
+        assert src_repo_current.repo_id == current_units[0].associate_source_repo_id
 
 
 @pytest.mark.parametrize("klass, method", [

--- a/ubipop/__init__.py
+++ b/ubipop/__init__.py
@@ -155,7 +155,12 @@ class UbiPopulate(object):
                     f.write(repo.strip() + '\n')
 
     def _get_ubi_repo_sets(self, ubi_config_item):
-
+        """
+        Searches for ubi repository triplet (binary rpm, srpm, debug) for
+        one ubi config item and tries to determine their population sources
+        (input repositories). Returns list UbiRepoSet objects that provides 
+        input and output repositories that are used for population process.
+        """
         rpm_repos_ft = self._executor.submit(self.pulp.search_repo_by_cs,
                                              ubi_config_item.content_sets.rpm.output)
         source_repos_ft = self._executor.submit(self.pulp.search_repo_by_cs,

--- a/ubipop/__init__.py
+++ b/ubipop/__init__.py
@@ -171,8 +171,8 @@ class UbiPopulate(object):
                 # it is sufficient to check only binary from repo triplet for disabling population
                 _LOG.debug(
                     "Skipping population for output binary repo and "
-                    "related source and debug repos:\n\t%s"
-                    % out_rpm_repo.repo_id)
+                    "related source and debug repos:\n\t%s",
+                    out_rpm_repo.repo_id)
                 continue
 
             out_source_repo = self.get_repo_counterpart(out_rpm_repo, source_repos_ft.result())

--- a/ubipop/_utils.py
+++ b/ubipop/_utils.py
@@ -37,56 +37,85 @@ class PulpAction(object):
         self.units = units
         self.dst_repo = dst_repo
 
-    def get_action(self, pulp_client_inst):
+    def get_actions(self, pulp_client_inst):
         raise NotImplementedError
 
 
 class AssociateAction(PulpAction):
-    def __init__(self, units, dst_repo, src_repo):
+    def __init__(self, units, dst_repo, src_repos):
         super(AssociateAction, self).__init__(units, dst_repo)
-        self.src_repo = src_repo
+        self.src_repos = src_repos
 
-    def get_action(self, pulp_client_inst):
+    def _map_src_repo_to_unit(self):
+        src_repo_unit_map = {}
+        for unit in self.units:
+            src_repo_unit_map.setdefault(unit.associate_source_repo_id, []).append(unit)
+
+        return src_repo_unit_map
+
+    def _get_repo_obj(self, repo_id):
+        for repo in self.src_repos:
+            if repo_id == repo.repo_id:
+                return repo
+
+    def get_actions(self, pulp_client_inst):
         raise NotImplementedError
 
 
 class AssociateActionModules(AssociateAction):
     TYPE = "modules"
 
-    def get_action(self, pulp_client_inst):
-        return pulp_client_inst.associate_modules, self.src_repo, self.dst_repo, self.units
+    def get_actions(self, pulp_client_inst):
+        actions = []
+        for src_repo_id, units in self._map_src_repo_to_unit().items():
+            actions.append((pulp_client_inst.associate_modules, self._get_repo_obj(src_repo_id),
+                            self.dst_repo, units))
+
+        return actions
 
 
 class UnassociateActionModules(PulpAction):
     TYPE = "modules"
 
-    def get_action(self, pulp_client_inst):
-        return pulp_client_inst.unassociate_modules, self.dst_repo, self.units
+    def get_actions(self, pulp_client_inst):
+        return [(pulp_client_inst.unassociate_modules, self.dst_repo, self.units)]
 
 
 class AssociateActionModuleDefaults(AssociateAction):
     TYPE = "module_defaults"
 
-    def get_action(self, pulp_client_inst):
-        return pulp_client_inst.associate_module_defaults, self.src_repo, self.dst_repo, self.units
+    def get_actions(self, pulp_client_inst):
+        actions = []
+        for src_repo_id, units in self._map_src_repo_to_unit().items():
+            actions.append((pulp_client_inst.associate_module_defaults,
+                            self._get_repo_obj(src_repo_id),
+                            self.dst_repo, units))
+
+        return actions
 
 
 class UnassociateActionModuleDefaults(PulpAction):
     TYPE = "module_defaults"
 
-    def get_action(self, pulp_client_inst):
-        return pulp_client_inst.unassociate_module_defaults, self.dst_repo, self.units
+    def get_actions(self, pulp_client_inst):
+        return [(pulp_client_inst.unassociate_module_defaults, self.dst_repo, self.units)]
 
 
 class AssociateActionRpms(AssociateAction):
     TYPE = "packages"
 
-    def get_action(self, pulp_client_inst):
-        return pulp_client_inst.associate_packages, self.src_repo, self.dst_repo, self.units
+    def get_actions(self, pulp_client_inst):
+        actions = []
+        for src_repo_id, units in self._map_src_repo_to_unit().items():
+            actions.append(
+                (pulp_client_inst.associate_packages,  self._get_repo_obj(src_repo_id),
+                 self.dst_repo, units))
+
+        return actions
 
 
 class UnassociateActionRpms(PulpAction):
     TYPE = "packages"
 
-    def get_action(self, pulp_client_inst):
-        return pulp_client_inst.unassociate_packages, self.dst_repo, self.units
+    def get_actions(self, pulp_client_inst):
+        return [(pulp_client_inst.unassociate_packages, self.dst_repo, self.units)]


### PR DESCRIPTION
This change adds support for ubi repositories population
from more that one input repo.

Repo note 'population_sources' is here used for
getting sources, if it's not available, fallback
to manual finding of input repositories.

This change also refactors usage of 'ubi_population' repo note
that enables population of given ubi repositories