### PR TITLE
Fix association of unwanted modular rpms [RHELDST-6453]

### DIFF
--- a/tests/test_ubipop.py
+++ b/tests/test_ubipop.py
@@ -1348,3 +1348,23 @@ def test_get_pkgs_from_all_modules(mock_ubipop_runner):
     assert len(pkgs) == 2
     assert "tomcatjss-7.3.6-1.el8+1944+b6c8e16f.noarch.rpm" in pkgs
     assert "tomcatjss-8.4.7-2.el8+1944+b6c8e16f.noarch.rpm" in pkgs
+
+
+def test_filter_pkgs_from_modules(mock_ubipop_runner):
+    mock_ubipop_runner.repos.modules['test5.30'] = [
+        get_test_mod(name="test", stream="5.30", packages=["tomcatjss-0:7.3.6-1.el8+1944+b6c8e16f.noarch"]),
+    ]
+
+    mock_ubipop_runner.repos.pkgs_from_modules['test5.30'] = [
+        get_test_pkg(
+            name="tomcatjss",
+            filename="tomcatjss-7.3.6-1.el8+1944+00000000.noarch.rpm",
+        ),
+        get_test_pkg(
+            name="tomcatjss",
+            filename="tomcatjss-7.3.6-1.el8+1944+b6c8e16f.noarch.rpm",
+        )]
+
+    mock_ubipop_runner._filter_pkgs_from_modules()
+    assert len(mock_ubipop_runner.repos.pkgs_from_modules['test5.30']) == 1
+    assert mock_ubipop_runner.repos.pkgs_from_modules['test5.30'][0].filename == "tomcatjss-7.3.6-1.el8+1944+b6c8e16f.noarch.rpm"

--- a/ubipop/__init__.py
+++ b/ubipop/__init__.py
@@ -605,7 +605,7 @@ class UbiPopulateRunner(object):
         return diff
 
     def _filter_pkgs_from_modules(self):
-        regex = r'^\d+:'
+        regex = r'\d+:'
         reg = re.compile(regex)
 
         for name_stream, packages in self.repos.pkgs_from_modules.items():

--- a/ubipop/__init__.py
+++ b/ubipop/__init__.py
@@ -605,7 +605,7 @@ class UbiPopulateRunner(object):
         return diff
 
     def _filter_pkgs_from_modules(self):
-        regex = r'\d+:'
+        regex = r'^\d+:'
         reg = re.compile(regex)
 
         for name_stream, packages in self.repos.pkgs_from_modules.items():

--- a/ubipop/__init__.py
+++ b/ubipop/__init__.py
@@ -604,6 +604,18 @@ class UbiPopulateRunner(object):
 
         return diff
 
+    def _filter_pkgs_from_modules(self):
+        regex = r'\d+:'
+        reg = re.compile(regex)
+
+        for name_stream, packages in self.repos.pkgs_from_modules.items():
+            # name_stream, packages == str, list of _pulp_client.Package
+
+            wanted_packages = list(chain.from_iterable([m.packages for m in self.repos.modules[name_stream]]))
+            wanted_packages = [reg.sub('', rpm_nevra) + '.rpm' for rpm_nevra in wanted_packages]
+            packages[:] = [pkg for pkg in packages if pkg.filename in wanted_packages]
+
+
     def run_ubi_population(self):
         current_modules_ft, current_module_defaults_ft, current_rpms_ft, \
             current_srpms_ft, current_debug_rpms_ft = self._get_current_content()
@@ -614,6 +626,7 @@ class UbiPopulateRunner(object):
             self._match_debug_rpms()
         self._exclude_blacklisted_packages()
         self._finalize_modules_output_set()
+        self._filter_pkgs_from_modules()
         self._finalize_rpms_output_set()
         self._finalize_debug_output_set()
         self._match_module_defaults()


### PR DESCRIPTION
This fixes a situation when modular packages are selected for output set
of ubi repo but they shouldn't be there because respective modulemd unit
is not selected as a content of ubi repo.

This lead to situations when a repo contained modular rpm from a
modulemd that wasn't associated with repo. This is wrong and could lead
to problems with packages installation from ubi repos.