### PR TITLE
Refactored with pubtools.pulplib.YumRepository

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 requests
-more-executors
+more-executors>2.1.0
 ubi-config>=2.2.0
 rpm-py-installer
 pyrsistent<0.17; python_version < '3'
+pubtools-pulplib>=2.9.0

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,7 @@
 import pytest
 
 from mock import MagicMock
+from pubtools.pulplib import YumRepository
 from ubipop._utils import (
     AssociateAction,
     AssociateActionModuleDefaults,
@@ -11,20 +12,19 @@ from ubipop._utils import (
     UnassociateActionModules,
     UnassociateActionRpms,
 )
-from ubipop._pulp_client import Repo
 
 
 def test_raise_not_implemented_pulp_action():
     units = ["unit1", "unit2"]
-    repo = Repo("test", "1", "test-rpms", "2", "2", "2", None, None, None)
+    repo = YumRepository(id="test")
     action = PulpAction(units, repo)
     pytest.raises(NotImplementedError, action.get_actions, None)
 
 
 def test_raise_not_implemented_associate_action():
     units = ["unit1", "unit2"]
-    repo = Repo("test", "1", "test-rpms", "2", "2", "2", None, None, None)
-    src_repo = Repo("test", "1", "test-rpms", "2", "2", "2", None, None, None)
+    repo = YumRepository(id="test")
+    src_repo = YumRepository(id="test")
     action = AssociateAction(units, repo, src_repo)
     pytest.raises(NotImplementedError, action.get_actions, None)
 
@@ -43,10 +43,11 @@ def test_get_action_associate(klass, method):
     mocked_unit_2 = MagicMock()
     mocked_unit_2.associate_source_repo_id = "test_src_2"
     units = [mocked_unit_1, mocked_unit_2]
-    dst_repo = Repo("test_dst", "1", "test_dst-rpms", "2", "2", "2", None, None, None)
+    dst_repo = YumRepository(id="test_dst")
+
     src_repos = [
-        Repo("test_src_1", "1", "test_src-rpms", "2", "2", "2", None, None, None),
-        Repo("test_src_2", "1", "test_src-rpms", "2", "2", "2", None, None, None),
+        YumRepository(id="test_src_1"),
+        YumRepository(id="test_src_2"),
     ]
     action = klass(units, dst_repo, src_repos)
     actions = action.get_actions(MagicMock())
@@ -55,10 +56,10 @@ def test_get_action_associate(klass, method):
         assert "mock." + method in str(associate_action)
         assert len(current_units) == 1
         assert current_units == [
-            u for u in units if u.associate_source_repo_id == src_repo_current.repo_id
+            u for u in units if u.associate_source_repo_id == src_repo_current.id
         ]
-        assert dst_repo_current.repo_id == dst_repo.repo_id
-        assert src_repo_current.repo_id == current_units[0].associate_source_repo_id
+        assert dst_repo_current.id == dst_repo.id
+        assert src_repo_current.id == current_units[0].associate_source_repo_id
 
 
 @pytest.mark.parametrize(
@@ -71,7 +72,7 @@ def test_get_action_associate(klass, method):
 )
 def test_get_action_unassociate(klass, method):
     units = ["unit1", "unit2"]
-    dst_repo = Repo("test_dst", "1", "test_dst-rpms", "2", "2", "2", None, None, None)
+    dst_repo = YumRepository(id="test_dst")
     action = klass(units, dst_repo)
     associate_action, dst_repo_current, current_units = action.get_actions(MagicMock())[
         0
@@ -79,4 +80,4 @@ def test_get_action_unassociate(klass, method):
 
     assert "mock." + method in str(associate_action)
     assert current_units == units
-    assert dst_repo_current.repo_id == dst_repo.repo_id
+    assert dst_repo_current.id == dst_repo.id

--- a/ubipop/_utils.py
+++ b/ubipop/_utils.py
@@ -55,7 +55,7 @@ class AssociateAction(PulpAction):
 
     def _get_repo_obj(self, repo_id):
         for repo in self.src_repos:
-            if repo_id == repo.repo_id:
+            if repo_id == repo.id:
                 return repo
 
     def get_actions(self, pulp_client_inst):


### PR DESCRIPTION
- Started using Client and YumRepository from pubtools.pulplib.
- It's still required to use to old client located in this repository
  until all interaction with pulp is refactored with pulplib.
- Getting ubi repo sets is now way easier with the latest updates in
  pulplib - we can directly ask for related source and debug repository
- Using only population_source repository attr., since it's populated
  for all ubi repositories
- Removed already unused code and updated tests
- Moved any expensive and difficult to mock calculations out of
  UbiPopulate.__init__()