### PR TITLE
Fix KeyError when profile is missing in modulemd

### DIFF
--- a/ubipop/_matcher.py
+++ b/ubipop/_matcher.py
@@ -240,7 +240,7 @@ class ModularMatcher(Matcher):
             # get rpm names from the modulemd profiles
             for profile in config_map.get(key) or []:
                 if module.profiles:
-                    pkgs_names.extend(module.profiles[profile])
+                    pkgs_names.extend(module.profiles.get(profile) or [])
 
             for filename in module.artifacts_filenames:
                 # skip source rpms


### PR DESCRIPTION
When ubi-config requests a profile from modulemd but
the profile is not in the modulemd, ubipop previously failed
with KeyError.

Now missing profile is not treated as a fatal error.