### PR TITLE
Make publication of repos non-blocking [RHELDST-6394]

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ ubi-config>=2.2.0
 rpm-py-installer
 pyrsistent<0.17; python_version < '3'
 pubtools-pulplib>=2.9.0
+attrs

--- a/tests/test_matcher.py
+++ b/tests/test_matcher.py
@@ -207,7 +207,7 @@ def test_search_rpms(pulp):
     matcher = Matcher(None, None)
     criteria = matcher._create_or_criteria(["filename"], [("test.x86_64.rpm",)])
     # let Future return result
-    result = matcher._search_rpms(criteria, [repo]).result()
+    result = matcher.search_rpms(criteria, [repo]).result()
     # there should be be only one unit in the result set according to criteria
     assert len(result) == 1
     assert result.pop().filename == "test.x86_64.rpm"
@@ -242,7 +242,7 @@ def test_search_srpms(pulp):
     matcher = Matcher(None, None)
     criteria = matcher._create_or_criteria(["filename"], [("test.src.rpm",)])
     # let Future return result
-    result = matcher._search_srpms(criteria, [repo]).result()
+    result = matcher.search_srpms(criteria, [repo]).result()
     # there should be be only one unit in the result set according to criteria
     assert len(result) == 1
     assert result.pop().filename == "test.src.rpm"
@@ -275,7 +275,7 @@ def test_search_moludemds(pulp):
     matcher = Matcher(None, None)
     criteria = matcher._create_or_criteria(["name", "stream"], [("test", "10")])
     # let Future return result
-    result = matcher._search_moludemds(criteria, [repo]).result()
+    result = matcher.search_modulemds(criteria, [repo]).result()
     # there should be be only one unit in the result set according to criteria
     assert len(result) == 1
     assert result.pop().nsvca == "test:10:100:abcdef:x86_64"
@@ -306,7 +306,7 @@ def test_search_moludemd_defaults(pulp):
     matcher = Matcher(None, None)
     criteria = matcher._create_or_criteria(["name", "stream"], [("test", "10")])
     # let Future return result
-    result = matcher._search_modulemd_defaults(criteria, [repo]).result()
+    result = matcher.search_modulemd_defaults(criteria, [repo]).result()
     # there should be be only one unit in the result set according to criteria
     assert len(result) == 1
     found_unit = result.pop()

--- a/tests/test_matcher.py
+++ b/tests/test_matcher.py
@@ -8,6 +8,7 @@ from pubtools.pulplib import (
     YumRepository,
     FakeController,
     ModulemdUnit,
+    ModulemdDefaultsUnit,
 )
 from ubiconfig import UbiConfig
 
@@ -280,6 +281,39 @@ def test_search_moludemds(pulp):
     assert result.pop().nsvca == "test:10:100:abcdef:x86_64"
 
 
+def test_search_moludemd_defaults(pulp):
+    """Test convenient method for searching modulemd_defaults"""
+    repo = YumRepository(
+        id="test_repo_1",
+    )
+    repo.__dict__["_client"] = pulp.client
+    unit_1 = ModulemdDefaultsUnit(
+        name="test",
+        stream="10",
+        repo_id="test_repo_1",
+        content_type_id="modulemd_defaults",
+    )
+    unit_2 = ModulemdDefaultsUnit(
+        name="test",
+        stream="20",
+        repo_id="test_repo_1",
+        content_type_id="modulemd_defaults",
+    )
+
+    pulp.insert_repository(repo)
+    pulp.insert_units(repo, [unit_1, unit_2])
+
+    matcher = Matcher(None, None)
+    criteria = matcher._create_or_criteria(["name", "stream"], [("test", "10")])
+    # let Future return result
+    result = matcher._search_modulemd_defaults(criteria, [repo]).result()
+    # there should be be only one unit in the result set according to criteria
+    assert len(result) == 1
+    found_unit = result.pop()
+    assert found_unit.name == "test"
+    assert found_unit.stream == "10"
+
+
 def test_modular_rpms_filenames(ubi_config):
     """Test getting filename from module artifacts, srpms are skipped."""
     matcher = ModularMatcher(None, ubi_config.modules)
@@ -490,6 +524,25 @@ def test_get_modulemds_criteria(ubi_config):
     # let's not test internal structure of criteria, that's responsibility of pulplib
 
 
+def test_get_modulemd_defaults_criteria():
+    """Test proper creation of criteria for modulemd_defaults query"""
+    matcher = ModularMatcher(None, None)
+    unit = UbiUnit(
+        ModulemdUnit(
+            name="test", stream="10", version=100, context="abcd", arch="x86_64"
+        ),
+        None,
+    )
+    matcher.modules = [unit]
+    criteria = matcher._get_modulemd_defaults_criteria()
+    # there should be 1 criterium created based on modules list of Matcher obj.
+    assert len(criteria) == 1
+    # it should be instance of Criteria
+    for crit in criteria:
+        assert isinstance(crit, Criteria)
+    # let's not test internal structure of criteria, that's responsibility of pulplib
+
+
 def test_get_modular_srpms_criteria(ubi_config):
     """Testing creation of criteria for srpms query"""
     matcher = ModularMatcher(None, ubi_config.modules)
@@ -614,10 +667,17 @@ def test_modular_matcher_run(pulp, ubi_config):
             "test-7:1.0-1.x86_64.src",
         ],
     )
+
+    modulemd_defaults = ModulemdDefaultsUnit(
+        name="fake_name",
+        stream="fake_stream",
+        repo_id="binary_repo",
+        content_type_id="modulemd_defaults",
+    )
     pulp.insert_repository(repo_1)
     pulp.insert_repository(repo_2)
     pulp.insert_repository(repo_3)
-    pulp.insert_units(repo_1, [unit_1, modulemd])
+    pulp.insert_units(repo_1, [unit_1, modulemd, modulemd_defaults])
     pulp.insert_units(repo_2, [unit_2])
     pulp.insert_units(repo_3, [unit_3])
 
@@ -627,6 +687,7 @@ def test_modular_matcher_run(pulp, ubi_config):
 
     # each public attribute is properly set with one unit
     assert len(matcher.modules) == 1
+    assert len(matcher.module_defaults) == 1
     assert len(matcher.binary_rpms) == 1
     assert len(matcher.debug_rpms) == 1
     assert len(matcher.source_rpms) == 1
@@ -635,6 +696,10 @@ def test_modular_matcher_run(pulp, ubi_config):
     output_module = matcher.modules.pop()
     assert output_module.nsvca == "fake_name:fake_stream:100:abcd:x86_64"
     assert output_module.associate_source_repo_id == "binary_repo"
+
+    output_modulemd_defaults = matcher.module_defaults.pop()
+    assert output_modulemd_defaults.name == "fake_name"
+    assert output_modulemd_defaults.stream == "fake_stream"
 
     rpm = matcher.binary_rpms.pop()
     assert rpm.filename == "test-1.0-1.x86_64.x86_64.rpm"

--- a/tests/test_pulp.py
+++ b/tests/test_pulp.py
@@ -229,7 +229,6 @@ def test_search_module_defaults(mock_pulp, mock_search_module_defaults, mock_rep
     assert len(found_module_defaults) == 1
     assert found_module_defaults[0].name == "virt"
     assert found_module_defaults[0].stream == "rhel"
-    assert found_module_defaults[0].name_profiles == "virt:[rhel:common,default]"
 
 
 @pytest.fixture(name="search_task_response")

--- a/tests/test_pulp.py
+++ b/tests/test_pulp.py
@@ -64,90 +64,6 @@ def fixture_mock_response_for_async_req():
     yield {"spawned_tasks": [{"task_id": "foo_task_id"}]}
 
 
-@pytest.fixture(name="search_rpms_response")
-def fixture_search_rpms_response(request):
-    try:
-        pkg_number = request.param
-    except AttributeError:
-        pkg_number = 1
-
-    yield [
-        {
-            "metadata": {
-                "name": "foo-pkg",
-                "filename": "foo-pkg.rpm",
-                "sourcerpm": "foo-pkg.src.rpm",
-                "is_modular": False,
-            }
-        }
-        for _ in range(pkg_number)
-    ]
-
-
-@pytest.fixture(name="search_modules_response")
-def fixture_search_modules_response():
-    yield [
-        {
-            "metadata": {
-                "name": "foo-module",
-                "stream": "9.6",
-                "version": 1111,
-                "context": "foo-context",
-                "arch": "x86_64",
-                "artifacts": ["foo-pkg"],
-                "profiles": {"foo-prof": ["pkg-name"]},
-            },
-        }
-    ]
-
-
-@pytest.fixture(name="search_module_defaults_response")
-def fixture_search_module_defaults_response():
-    yield [
-        {
-            "metadata": {
-                "name": "virt",
-                "stream": "rhel",
-                "profiles": {"rhel": ["default", "common"]},
-            },
-        }
-    ]
-
-
-@pytest.fixture(name="mock_search_rpms")
-def fixture_mock_search_rpms(requests_mock, mock_repo, search_rpms_response):
-    url = "/pulp/api/v2/repositories/{REPO_ID}/search/units/".format(
-        REPO_ID=mock_repo.id
-    )
-    requests_mock.register_uri("POST", url, json=search_rpms_response)
-
-
-@pytest.fixture(name="mock_search_modules")
-def fixture_mock_search_modules(requests_mock, mock_repo, search_modules_response):
-    url = "/pulp/api/v2/repositories/{REPO_ID}/search/units/".format(
-        REPO_ID=mock_repo.id
-    )
-    requests_mock.register_uri("POST", url, json=search_modules_response)
-
-
-@pytest.fixture(name="mock_search_module_defaults")
-def fixture_mock_search_module_defaults(
-    requests_mock, mock_repo, search_module_defaults_response
-):
-    url = "/pulp/api/v2/repositories/{REPO_ID}/search/units/".format(
-        REPO_ID=mock_repo.id
-    )
-    requests_mock.register_uri("POST", url, json=search_module_defaults_response)
-
-
-@pytest.fixture(name="mock_publish")
-def fixture_mock_publish(requests_mock, mock_repo, mock_response_for_async_req):
-    url = "/pulp/api/v2/repositories/{repo_id}/actions/publish/".format(
-        repo_id=mock_repo.id
-    )
-    requests_mock.register_uri("POST", url, json=mock_response_for_async_req)
-
-
 @pytest.fixture(name="mock_associate")
 def fixture_mock_associate(requests_mock, mock_repo, mock_response_for_async_req):
     url = "/pulp/api/v2/repositories/{dst_repo}/actions/associate/".format(
@@ -190,45 +106,6 @@ def test_unassociate_module_defaults(mock_pulp, mock_unassociate, mock_repo, moc
     task_ids = mock_pulp.unassociate_module_defaults(mock_repo, [mock_mdd])
     assert task_ids
     assert task_ids[0] == "foo_task_id"
-
-
-def test_search_rpms(mock_pulp, mock_search_rpms, mock_repo):
-    # pylint: disable=unused-argument
-    found_rpms = mock_pulp.search_rpms(mock_repo)
-    assert len(found_rpms) == 1
-    assert found_rpms[0].name == "foo-pkg"
-    assert found_rpms[0].filename == "foo-pkg.rpm"
-    assert found_rpms[0].sourcerpm == "foo-pkg.src.rpm"
-    assert found_rpms[0].is_modular is False
-
-
-@pytest.mark.parametrize("search_rpms_response", [0, 1, 2], indirect=True)
-def test_search_rpms_by_filename(
-    mock_pulp, mock_search_rpms, mock_repo, search_rpms_response
-):
-    # pylint: disable=unused-argument
-    found_rpms = mock_pulp.search_rpms(mock_repo, filename="foo-pkg.rpm")
-    assert len(search_rpms_response) == len(found_rpms)
-
-
-def test_search_modules(mock_pulp, mock_search_modules, mock_repo):
-    # pylint: disable=unused-argument
-    found_modules = mock_pulp.search_modules(mock_repo)
-    assert len(found_modules) == 1
-
-    assert found_modules[0].nsvca == "foo-module:9.6:1111:foo-context:x86_64"
-    assert found_modules[0].packages == ["foo-pkg"]
-    assert found_modules[0].profiles == {"foo-prof": ["pkg-name"]}
-
-
-def test_search_module_defaults(mock_pulp, mock_search_module_defaults, mock_repo):
-    # pylint: disable=unused-argument
-    found_module_defaults = mock_pulp.search_module_defaults(
-        mock_repo, name="virt", stream="rhel"
-    )
-    assert len(found_module_defaults) == 1
-    assert found_module_defaults[0].name == "virt"
-    assert found_module_defaults[0].stream == "rhel"
 
 
 @pytest.fixture(name="search_task_response")

--- a/tests/test_ubipop.py
+++ b/tests/test_ubipop.py
@@ -16,6 +16,7 @@ from pubtools.pulplib import (
     Distributor,
     ModulemdUnit,
     RpmUnit,
+    ModulemdDefaultsUnit,
 )
 from mock import MagicMock, patch, call
 from more_executors import Executors
@@ -408,7 +409,6 @@ def test_match_module_defaults(mock_ubipop_runner):
     md_d = mock_ubipop_runner.repos.module_defaults["virtrhel"]
     assert len(md_d) == 1
     assert md_d[0].name == "virt"
-    assert md_d[0].name_profiles == "virt:[2.5:common]"
 
 
 def test_diff_modules(mock_ubipop_runner):
@@ -608,13 +608,18 @@ def test_get_pulp_actions(mock_ubipop_runner, mock_current_content_ft):
         f_return(set([get_test_mod(name="test_md", pulplib=True)]))
     )
 
-    mock_ubipop_runner.repos.module_defaults = {
-        "test": [
-            get_test_mod_defaults(
-                name="test_mdd", stream="rhel", profiles={"2.5": "uncommon"}
+    mock_ubipop_runner.repos.module_defaults = [
+        UbiUnit(
+            ModulemdDefaultsUnit(
+                name="test_mdd",
+                stream="rhel",
+                profiles={"2.5": "uncommon"},
+                repo_id="foo-rpms",
+                content_type_id="modulemd_defaults",
             ),
-        ],
-    }
+            "foo-rpms",
+        )
+    ]
 
     binary_rpms = [
         UbiUnit(
@@ -766,13 +771,19 @@ def test_get_pulp_actions_no_actions(mock_ubipop_runner, mock_current_content_ft
     mock_ubipop_runner.repos.modules = f_proxy(
         f_return(set([get_test_mod(name="md_current", pulplib=True)]))
     )
-    mock_ubipop_runner.repos.module_defaults = {
-        "test": [
-            get_test_mod_defaults(
-                name="mdd_current", stream="rhel", profiles={"2.5": "common"}
+
+    mock_ubipop_runner.repos.module_defaults = [
+        UbiUnit(
+            ModulemdDefaultsUnit(
+                name="mdd_current",
+                stream="rhel",
+                profiles={"2.5": "common"},
+                repo_id="foo-rpms",
+                content_type_id="modulemd_defaults",
             ),
-        ],
-    }
+            "foo-rpms",
+        )
+    ]
 
     binary_rpms = [
         UbiUnit(
@@ -906,13 +917,19 @@ def test_get_pulp_no_duplicates(mock_ubipop_runner, mock_current_content_ft):
     mock_ubipop_runner.repos.modules = f_proxy(
         f_return(set([get_test_mod(name="md_current", pulplib=True)]))
     )
-    mock_ubipop_runner.repos.module_defaults = {
-        "test": [
-            get_test_mod_defaults(
-                name="mdd_current", stream="rhel", profiles={"2.5": "common"}
-            )
-        ]
-    }
+
+    mock_ubipop_runner.repos.module_defaults = [
+        UbiUnit(
+            ModulemdDefaultsUnit(
+                name="mdd_current",
+                stream="rhel",
+                profiles={"2.5": "common"},
+                repo_id="foo-rpms",
+                content_type_id="modulemd_defaults",
+            ),
+            "foo-rpms",
+        )
+    ]
 
     binary_rpms = [
         UbiUnit(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,7 +1,7 @@
 import pytest
 
 from mock import MagicMock
-from pubtools.pulplib import YumRepository, RpmUnit
+from pubtools.pulplib import YumRepository, RpmUnit, ModulemdDefaultsUnit
 from ubipop._utils import (
     AssociateAction,
     AssociateActionModuleDefaults,
@@ -12,6 +12,7 @@ from ubipop._utils import (
     UnassociateActionModules,
     UnassociateActionRpms,
     vercmp_sort,
+    flatten_md_defaults_name_profiles,
 )
 from ubipop._matcher import UbiUnit
 
@@ -121,3 +122,20 @@ def test_vercmp_sort():
     assert (unit_1 >= unit_2) is False
     assert (unit_1 > unit_2) is False
     assert (unit_1 != unit_2) is True
+
+
+def test_flatten_md_defaults_name_profiles():
+    unit = UbiUnit(
+        ModulemdDefaultsUnit(
+            content_type_id="modulemd_defaults",
+            name="test",
+            stream="foo",
+            profiles={"rhel": ["common", "uncommon"], "fedora": ["super", "ultra"]},
+            repo_id="foo-repo",
+        ),
+        "foo-repo",
+    )
+
+    out = flatten_md_defaults_name_profiles(unit)
+
+    assert out == "test:[fedora:super,ultra]:[rhel:common,uncommon]"

--- a/ubipop/_matcher.py
+++ b/ubipop/_matcher.py
@@ -66,8 +66,9 @@ class Matcher(object):
         """
         raise NotImplementedError
 
+    @classmethod
     def _search_units(
-        self, repo, criteria_list, content_type_id, batch_size_override=None
+        cls, repo, criteria_list, content_type_id, batch_size_override=None
     ):
         """
         Search for units of one content type associated with given repository by criteria.
@@ -122,13 +123,14 @@ class Matcher(object):
 
         return or_criteria
 
+    @classmethod
     def _search_units_per_repos(
-        self, or_criteria, repos, content_type, batch_size_override=None
+        cls, or_criteria, repos, content_type, batch_size_override=None
     ):
         units = []
         for repo in repos:
             units.append(
-                self._search_units(
+                cls._search_units(
                     repo,
                     or_criteria,
                     content_type,
@@ -138,27 +140,31 @@ class Matcher(object):
 
         return f_proxy(f_flat_map(f_sequence(units), flatten_list_of_sets))
 
-    def _search_rpms(self, or_criteria, repos, batch_size_override=None):
-        return self._search_units_per_repos(
+    @classmethod
+    def search_rpms(cls, or_criteria, repos, batch_size_override=None):
+        return cls._search_units_per_repos(
             or_criteria,
             repos,
             content_type="rpm",
             batch_size_override=batch_size_override,
         )
 
-    def _search_srpms(self, or_criteria, repos, batch_size_override=None):
-        return self._search_units_per_repos(
+    @classmethod
+    def search_srpms(cls, or_criteria, repos, batch_size_override=None):
+        return cls._search_units_per_repos(
             or_criteria,
             repos,
             content_type="srpm",
             batch_size_override=batch_size_override,
         )
 
-    def _search_moludemds(self, or_criteria, repos):
-        return self._search_units_per_repos(or_criteria, repos, content_type="modulemd")
+    @classmethod
+    def search_modulemds(cls, or_criteria, repos):
+        return cls._search_units_per_repos(or_criteria, repos, content_type="modulemd")
 
-    def _search_modulemd_defaults(self, or_criteria, repos):
-        return self._search_units_per_repos(
+    @classmethod
+    def search_modulemd_defaults(cls, or_criteria, repos):
+        return cls._search_units_per_repos(
             or_criteria, repos, content_type="modulemd_defaults"
         )
 
@@ -195,7 +201,7 @@ class ModularMatcher(Matcher):
         )
         modules = f_proxy(
             self._executor.submit(
-                self._search_moludemds, modulemds_criteria, self._input_repos.rpm
+                self.search_modulemds, modulemds_criteria, self._input_repos.rpm
             )
         )
         self.modules = f_proxy(
@@ -204,18 +210,18 @@ class ModularMatcher(Matcher):
         rpms_criteria = f_proxy(self._executor.submit(self._get_modular_rpms_criteria))
         self.binary_rpms = f_proxy(
             self._executor.submit(
-                self._search_rpms, rpms_criteria, self._input_repos.rpm
+                self.search_rpms, rpms_criteria, self._input_repos.rpm
             )
         )
         self.debug_rpms = f_proxy(
             self._executor.submit(
-                self._search_rpms, rpms_criteria, self._input_repos.debug
+                self.search_rpms, rpms_criteria, self._input_repos.debug
             )
         )
         srpms_criteria = f_proxy(self._executor.submit(self._get_srpms_criteria))
         self.source_rpms = f_proxy(
             self._executor.submit(
-                self._search_srpms, srpms_criteria, self._input_repos.source
+                self.search_srpms, srpms_criteria, self._input_repos.source
             )
         )
         modulemd_defaults_criteria = f_proxy(
@@ -223,7 +229,7 @@ class ModularMatcher(Matcher):
         )
         self.module_defaults = f_proxy(
             self._executor.submit(
-                self._search_modulemd_defaults,
+                self.search_modulemd_defaults,
                 modulemd_defaults_criteria,
                 self._input_repos.rpm,
             )
@@ -339,7 +345,7 @@ class RpmMatcher(Matcher):
 
         binary_rpms = f_proxy(
             self._executor.submit(
-                self._search_rpms,
+                self.search_rpms,
                 rpms_criteria,
                 self._input_repos.rpm,
                 batch_size_override,
@@ -348,7 +354,7 @@ class RpmMatcher(Matcher):
 
         debug_rpms = f_proxy(
             self._executor.submit(
-                self._search_rpms,
+                self.search_rpms,
                 rpms_criteria,
                 self._input_repos.debug,
                 batch_size_override,
@@ -369,7 +375,7 @@ class RpmMatcher(Matcher):
         srpms_criteria = f_proxy(self._executor.submit(self._get_srpms_criteria))
         source_rpms = f_proxy(
             self._executor.submit(
-                self._search_srpms,
+                self.search_srpms,
                 srpms_criteria,
                 self._input_repos.source,
                 batch_size_override,
@@ -418,7 +424,7 @@ class RpmMatcher(Matcher):
 
             return modular_rpm_filenames
 
-        modules = self._search_moludemds([Criteria.true()], self._input_repos.rpm)
+        modules = self.search_modulemds([Criteria.true()], self._input_repos.rpm)
         return self._executor.submit(extract_modular_filenames)
 
     def _get_rpm_output_set(

--- a/ubipop/_pulp_client.py
+++ b/ubipop/_pulp_client.py
@@ -4,7 +4,6 @@ import threading
 import time
 
 from urllib3.util.retry import Retry
-from ubipop._utils import split_filename
 
 try:
     from urllib.parse import urljoin
@@ -89,91 +88,6 @@ class Pulp(object):
             ret = None
 
         return ret
-
-    def search_rpms(
-        self, repo, name=None, arch=None, name_globbing=False, filename=None
-    ):
-        url = "repositories/{REPO_ID}/search/units/".format(REPO_ID=repo.id)
-        criteria = {"type_ids": ["rpm", "srpm"]}
-
-        filters = {"filters": {"unit": {}}}
-        if name:
-            if name_globbing:
-                filters["filters"]["unit"]["name"] = {"$regex": name + ".*"}
-            else:
-                filters["filters"]["unit"]["name"] = name
-
-        if arch:
-            filters["filters"]["unit"]["arch"] = arch
-
-        if filename:
-            filters["filters"]["unit"]["filename"] = filename
-
-        criteria.update(filters)
-        payload = {"criteria": criteria}
-        ret = self.do_request("post", url, payload)
-        rpms = []
-        ret.raise_for_status()
-        for item in ret.json():
-            metadata = item["metadata"]
-            rpms.append(
-                Package(
-                    metadata["name"],
-                    metadata["filename"],
-                    repo.id,
-                    sourcerpm_filename=metadata.get("sourcerpm"),
-                )
-            )
-        return rpms
-
-    def search_modules(self, repo, name=None, stream=None):
-        url = "repositories/{REPO_ID}/search/units/".format(REPO_ID=repo.id)
-        criteria = {"type_ids": ["modulemd"]}
-        if name and stream:
-            criteria.update({"filters": {"unit": {"name": name, "stream": stream}}})
-        payload = {"criteria": criteria}
-
-        ret = self.do_request("post", url, payload)
-        modules = []
-        ret.raise_for_status()
-        for item in ret.json():
-
-            metadata = item["metadata"]
-            modules.append(
-                Module(
-                    metadata["name"],
-                    metadata["stream"],
-                    metadata["version"],
-                    metadata["context"],
-                    metadata["arch"],
-                    metadata["artifacts"],
-                    metadata["profiles"],
-                    repo.id,
-                )
-            )
-        return modules
-
-    def search_module_defaults(self, repo, name=None, stream=None):
-        url = "repositories/{REPO_ID}/search/units/".format(REPO_ID=repo.id)
-        criteria = {"type_ids": ["modulemd_defaults"]}
-        if name and stream:
-            criteria.update({"filters": {"unit": {"name": name, "stream": stream}}})
-        payload = {"criteria": criteria}
-
-        ret = self.do_request("post", url, payload)
-        ret.raise_for_status()
-        module_defaults = []
-        for item in ret.json():
-            metadata = item["metadata"]
-            module_defaults.append(
-                ModuleDefaults(
-                    metadata["name"],
-                    metadata["stream"],
-                    metadata["profiles"],
-                    repo.id,
-                )
-            )
-        return module_defaults
 
     def wait_for_tasks(self, task_id_list, delay=5.0):
         results = {}
@@ -290,68 +204,3 @@ class Pulp(object):
 
     def unassociate_packages(self, repo, rpms):
         return self.unassociate_units(repo, rpms, ("rpm", "srpm"))
-
-
-class Package(object):
-    def __init__(
-        self, name, filename, src_repo_id, sourcerpm_filename=None, is_modular=False
-    ):
-        self.name = name
-        self.filename = filename
-        self.sourcerpm = sourcerpm_filename
-        self.is_modular = is_modular
-        #  return name, ver, rel, epoch, arch
-        _, self.version, self.release, self.epoch, _ = split_filename(self.filename)
-        self.associate_source_repo_id = src_repo_id
-
-    def __str__(self):
-        return self.filename
-
-
-class Module(object):
-    def __init__(
-        self, name, stream, version, context, arch, packages, profiles, src_repo_id
-    ):
-        self.name = name
-        self.stream = stream
-        self.version = version
-        self.context = context
-        self.arch = arch
-        self.packages = packages
-        self.profiles = profiles
-        self.associate_source_repo_id = src_repo_id
-
-    @property
-    def nsvca(self):
-        return ":".join(
-            (self.name, self.stream, str(self.version), self.context, self.arch)
-        )
-
-    def __str__(self):
-        return self.nsvca
-
-
-class ModuleDefaults(object):
-    """
-    module_defaults unit, defines which profiles are enabled by default when activating
-    a module. For example:
-    {...,
-     "name": "ruby",
-     "profiles": {
-        "2.5": [
-            "common"]
-        },
-    ...
-    }
-    if someone asks to enable 'ruby:2.5' for some repo without specifing profiles, will
-    get 'common' profile by defualt
-    """
-
-    def __init__(self, name, stream, profiles, src_repo_id):
-        self.name = name
-        self.stream = stream
-        self.profiles = profiles  # a dict such as {'4.046':['common']}
-        self.associate_source_repo_id = src_repo_id
-
-    def __str__(self):
-        return self.name

--- a/ubipop/_pulp_client.py
+++ b/ubipop/_pulp_client.py
@@ -355,15 +355,3 @@ class ModuleDefaults(object):
 
     def __str__(self):
         return self.name
-
-    @property
-    def name_profiles(self):
-        """
-        flatten the profles and prepend name
-        format: name:[key:profile,profile]:[key:profile]
-        'ruby:[2.5:common,unique]'
-        """
-        result = self.name
-        for key in sorted(self.profiles):
-            result += ":[%s:%s]" % (key, ",".join(sorted(self.profiles[key])))
-        return result

--- a/ubipop/_utils.py
+++ b/ubipop/_utils.py
@@ -1,38 +1,5 @@
 from rpm import labelCompare as label_compare  # pylint: disable=no-name-in-module
 
-# borrowed from https://github.com/rpm-software-management/yum
-def split_filename(filename):
-    """
-    Pass in a standard style rpm fullname
-
-    Return a name, version, release, epoch, arch, e.g.::
-        foo-1.0-1.i386.rpm returns foo, 1.0, 1, i386
-        1:bar-9-123a.ia64.rpm returns bar, 9, 123a, 1, ia64
-    """
-
-    if filename[-4:] == ".rpm":
-        filename = filename[:-4]
-
-    arch_index = filename.rfind(".")
-    arch = filename[arch_index + 1 :]
-
-    rel_index = filename[:arch_index].rfind("-")
-    rel = filename[rel_index + 1 : arch_index]
-
-    ver_index = filename[:rel_index].rfind("-")
-    ver = filename[ver_index + 1 : rel_index]
-
-    epoch_index = filename.find(":")
-
-    if epoch_index == -1:
-        epoch = ""
-    else:
-        epoch = filename[:epoch_index]
-
-    name = filename[epoch_index + 1 : ver_index]
-
-    return name, ver, rel, epoch, arch
-
 
 class PulpAction(object):
     def __init__(self, units, dst_repo):

--- a/ubipop/_utils.py
+++ b/ubipop/_utils.py
@@ -165,3 +165,15 @@ def vercmp_sort():
             return label_compare(self.evr_tuple, other.evr_tuple) != 0
 
     return Klass
+
+
+def flatten_md_defaults_name_profiles(obj):
+    """
+    flatten the profiles of md_defaults unit and prepend name
+    format: name:[key:profile,profile]:[key:profile]
+    'ruby:[2.5:common,unique]'
+    """
+    result = obj.name
+    for key in sorted(obj.profiles):
+        result += ":[%s:%s]" % (key, ",".join(sorted(obj.profiles[key])))
+    return result

--- a/ubipop/test_attr.py
+++ b/ubipop/test_attr.py
@@ -1,0 +1,12 @@
+import attr
+import inspect
+
+
+@attr.s
+class Coordinates(object):
+    x = attr.ib()
+
+
+print(inspect.getsource(Coordinates.__init__))
+##xxx = XXX(100, 200)#
+# print(xxx.x)


### PR DESCRIPTION
Previously ubipop waited for each triplet of repos
(binary, debug, source) that were currently
in processing until publication of those repos
is finished. Only after publication finished,
ubipop was allowed to start processing another triplet.
As repo triplet is independent from other ones, it's
not required to do this in blocking way. So now
publication of repos is triggered at the same time
as before but waiting for all to finish is moved to
end of ubipop processing.