### PR TITLE
Rework matching modulemd_defaults units [RHELDST-6393]

### DIFF
--- a/tests/test_pulp.py
+++ b/tests/test_pulp.py
@@ -229,7 +229,6 @@ def test_search_module_defaults(mock_pulp, mock_search_module_defaults, mock_rep
     assert len(found_module_defaults) == 1
     assert found_module_defaults[0].name == "virt"
     assert found_module_defaults[0].stream == "rhel"
-    assert found_module_defaults[0].name_profiles == "virt:[rhel:common,default]"
 
 
 @pytest.fixture(name="search_task_response")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,7 +1,7 @@
 import pytest
 
 from mock import MagicMock
-from pubtools.pulplib import YumRepository, RpmUnit
+from pubtools.pulplib import YumRepository, RpmUnit, ModulemdDefaultsUnit
 from ubipop._utils import (
     AssociateAction,
     AssociateActionModuleDefaults,
@@ -12,6 +12,7 @@ from ubipop._utils import (
     UnassociateActionModules,
     UnassociateActionRpms,
     vercmp_sort,
+    flatten_md_defaults_name_profiles,
 )
 from ubipop._matcher import UbiUnit
 
@@ -121,3 +122,19 @@ def test_vercmp_sort():
     assert (unit_1 >= unit_2) is False
     assert (unit_1 > unit_2) is False
     assert (unit_1 != unit_2) is True
+
+
+def test_flatten_md_defaults_name_profiles():
+    unit = UbiUnit(
+        ModulemdDefaultsUnit(
+            name="test",
+            stream="foo",
+            profiles={"rhel": ["common", "uncommon"], "fedora": ["super", "ultra"]},
+            repo_id="foo-repo",
+        ),
+        "foo-repo",
+    )
+
+    out = flatten_md_defaults_name_profiles(unit)
+
+    assert out == "test:[fedora:super,ultra]:[rhel:common,uncommon]"

--- a/ubipop/_matcher.py
+++ b/ubipop/_matcher.py
@@ -157,6 +157,11 @@ class Matcher(object):
     def _search_moludemds(self, or_criteria, repos):
         return self._search_units_per_repos(or_criteria, repos, content_type="modulemd")
 
+    def _search_modulemd_defaults(self, or_criteria, repos):
+        return self._search_units_per_repos(
+            or_criteria, repos, content_type="modulemd_defaults"
+        )
+
     def _get_srpms_criteria(self):
         filenames = []
         for rpms_list in as_completed([self.binary_rpms, self.debug_rpms]):
@@ -176,6 +181,7 @@ class ModularMatcher(Matcher):
     def __init__(self, input_repos, ubi_config):
         super(ModularMatcher, self).__init__(input_repos, ubi_config)
         self.modules = None
+        self.modulemd_defaults = None
 
     def run(self):
         """Asynchronously creates criteria for pulp queries and
@@ -212,6 +218,16 @@ class ModularMatcher(Matcher):
                 self._search_srpms, srpms_criteria, self._input_repos.source
             )
         )
+        modulemd_defaults_criteria = f_proxy(
+            self._executor.submit(self._get_modulemd_defaults_criteria)
+        )
+        self.modulemd_defaults = f_proxy(
+            self._executor.submit(
+                self._search_modulemd_defaults,
+                modulemd_defaults_criteria,
+                self._input_repos.rpm,
+            )
+        )
         return self
 
     def _get_modular_rpms_criteria(self):
@@ -221,8 +237,14 @@ class ModularMatcher(Matcher):
         return pkgs_or_criteria
 
     def _get_modulemds_criteria(self):
+        return self._get_criteria_for_modules(self._ubi_config)
+
+    def _get_modulemd_defaults_criteria(self):
+        return self._get_criteria_for_modules(self.modules)
+
+    def _get_criteria_for_modules(self, modules):
         criteria_values = []
-        for module in self._ubi_config:
+        for module in modules:
             criteria_values.append(
                 (
                     module.name,

--- a/ubipop/_pulp_client.py
+++ b/ubipop/_pulp_client.py
@@ -355,15 +355,3 @@ class ModuleDefaults(object):
 
     def __str__(self):
         return self.name
-
-    @property
-    def name_profiles(self):
-        """
-        flatten the profles and prepend name
-        format: name:[key:profile,profile]:[key:profile]
-        'ruby:[2.5:common,unique]'
-        """
-        result = self.name
-        for key in sorted(self.profiles):
-            result += ":[%s:%s]" % (key, ",".join(sorted(self.profiles[key])))
-        return result

--- a/ubipop/_utils.py
+++ b/ubipop/_utils.py
@@ -165,3 +165,15 @@ def vercmp_sort():
             return label_compare(self.evr_tuple, other.evr_tuple) != 0
 
     return Klass
+
+
+def flatten_md_defaults_name_profiles(obj):
+    """
+    flatten the profiles of md_defaults unit and prepend name
+    format: name:[key:profile,profile]:[key:profile]
+    'ruby:[2.5:common,unique]'
+    """
+    result = obj.name
+    for key in sorted(obj.profiles):
+        result += ":[%s:%s]" % (key, ",".join(sorted(obj.profiles[key])))
+    return result


### PR DESCRIPTION
Matching modulemd_defaults units for ubi repos population is now
reworked and uses Client from pubtools-pulplib in the similar way
as matching other units (modulemd, rpm ...) works.