### PR TITLE
Refactored getting current content from ubi repos

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ ubi-config>=2.2.0
 rpm-py-installer
 pyrsistent<0.17; python_version < '3'
 pubtools-pulplib>=2.9.0
+attrs

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,32 @@
+import pytest
+
+from pubtools.pulplib import RpmUnit, ModulemdUnit, ModulemdDefaultsUnit, FakeController
+from ubipop._matcher import UbiUnit
+
+
+def _get_test_unit(klass, **kwargs):
+    repo_id = kwargs.pop("src_repo_id")
+    return UbiUnit(klass(**kwargs), repo_id)
+
+
+def get_rpm_unit(**kwargs):
+    return _get_test_unit(RpmUnit, **kwargs)
+
+
+def get_srpm_unit(**kwargs):
+    kwargs["content_type_id"] = "srpm"
+    kwargs["arch"] = "src"
+    return _get_test_unit(RpmUnit, **kwargs)
+
+
+def get_modulemd_unit(**kwargs):
+    return _get_test_unit(ModulemdUnit, **kwargs)
+
+
+def get_modulemd_defaults_unit(**kwargs):
+    return _get_test_unit(ModulemdDefaultsUnit, **kwargs)
+
+
+@pytest.fixture(name="pulp")
+def fake_pulp():
+    yield FakeController()

--- a/tests/test_matcher.py
+++ b/tests/test_matcher.py
@@ -6,7 +6,6 @@ from pubtools.pulplib import (
     RpmUnit,
     Criteria,
     YumRepository,
-    FakeController,
     ModulemdUnit,
     ModulemdDefaultsUnit,
 )
@@ -21,11 +20,6 @@ from ubipop._matcher import (
 )
 from ubipop import RepoSet
 from ubipop._utils import vercmp_sort
-
-
-@pytest.fixture(name="pulp")
-def fake_pulp():
-    yield FakeController()
 
 
 @pytest.fixture(name="ubi_config")
@@ -207,7 +201,7 @@ def test_search_rpms(pulp):
     matcher = Matcher(None, None)
     criteria = matcher._create_or_criteria(["filename"], [("test.x86_64.rpm",)])
     # let Future return result
-    result = matcher._search_rpms(criteria, [repo]).result()
+    result = matcher.search_rpms(criteria, [repo]).result()
     # there should be be only one unit in the result set according to criteria
     assert len(result) == 1
     assert result.pop().filename == "test.x86_64.rpm"
@@ -242,7 +236,7 @@ def test_search_srpms(pulp):
     matcher = Matcher(None, None)
     criteria = matcher._create_or_criteria(["filename"], [("test.src.rpm",)])
     # let Future return result
-    result = matcher._search_srpms(criteria, [repo]).result()
+    result = matcher.search_srpms(criteria, [repo]).result()
     # there should be be only one unit in the result set according to criteria
     assert len(result) == 1
     assert result.pop().filename == "test.src.rpm"
@@ -275,7 +269,7 @@ def test_search_moludemds(pulp):
     matcher = Matcher(None, None)
     criteria = matcher._create_or_criteria(["name", "stream"], [("test", "10")])
     # let Future return result
-    result = matcher._search_moludemds(criteria, [repo]).result()
+    result = matcher.search_modulemds(criteria, [repo]).result()
     # there should be be only one unit in the result set according to criteria
     assert len(result) == 1
     assert result.pop().nsvca == "test:10:100:abcdef:x86_64"
@@ -304,7 +298,7 @@ def test_search_moludemd_defaults(pulp):
     matcher = Matcher(None, None)
     criteria = matcher._create_or_criteria(["name", "stream"], [("test", "10")])
     # let Future return result
-    result = matcher._search_modulemd_defaults(criteria, [repo]).result()
+    result = matcher.search_modulemd_defaults(criteria, [repo]).result()
     # there should be be only one unit in the result set according to criteria
     assert len(result) == 1
     found_unit = result.pop()

--- a/tests/test_pulp.py
+++ b/tests/test_pulp.py
@@ -16,7 +16,12 @@ from requests.exceptions import HTTPError
 
 from pubtools.pulplib import YumRepository
 from ubipop import _pulp_client as pulp_client
-from ubipop._pulp_client import Package, ModuleDefaults, Pulp, PulpRetryAdapter
+from ubipop._pulp_client import Pulp, PulpRetryAdapter
+
+from .conftest import (
+    get_rpm_unit,
+    get_modulemd_defaults_unit,
+)
 
 ORIG_HTTP_TOTAL_RETRIES = pulp_client.HTTP_TOTAL_RETRIES
 ORIG_HTTP_RETRY_BACKOFF = pulp_client.HTTP_RETRY_BACKOFF
@@ -51,101 +56,30 @@ def fixture_mock_repo():
 
 @pytest.fixture(name="mock_package")
 def fixture_mock_package():
-    yield Package("foo-pkg", "foo-pkg.rpm", "src_repo_id")
+    yield get_rpm_unit(
+        name="foo-pkg",
+        version="10",
+        release="1",
+        arch="x86_64",
+        filename="foo-pkg.rpm",
+        src_repo_id="src_repo_id",
+    )
 
 
 @pytest.fixture(name="mock_mdd")
 def fixture_mock_mdd():
-    yield ModuleDefaults("virt", "rhel", {"2.6": ["common"]}, "src_repo_id")
+    yield get_modulemd_defaults_unit(
+        name="virt",
+        stream="rhel",
+        profiles={"2.6": ["common"]},
+        repo_id="src_repo_id",
+        src_repo_id="src_repo_id",
+    )
 
 
 @pytest.fixture(name="mock_response_for_async_req")
 def fixture_mock_response_for_async_req():
     yield {"spawned_tasks": [{"task_id": "foo_task_id"}]}
-
-
-@pytest.fixture(name="search_rpms_response")
-def fixture_search_rpms_response(request):
-    try:
-        pkg_number = request.param
-    except AttributeError:
-        pkg_number = 1
-
-    yield [
-        {
-            "metadata": {
-                "name": "foo-pkg",
-                "filename": "foo-pkg.rpm",
-                "sourcerpm": "foo-pkg.src.rpm",
-                "is_modular": False,
-            }
-        }
-        for _ in range(pkg_number)
-    ]
-
-
-@pytest.fixture(name="search_modules_response")
-def fixture_search_modules_response():
-    yield [
-        {
-            "metadata": {
-                "name": "foo-module",
-                "stream": "9.6",
-                "version": 1111,
-                "context": "foo-context",
-                "arch": "x86_64",
-                "artifacts": ["foo-pkg"],
-                "profiles": {"foo-prof": ["pkg-name"]},
-            },
-        }
-    ]
-
-
-@pytest.fixture(name="search_module_defaults_response")
-def fixture_search_module_defaults_response():
-    yield [
-        {
-            "metadata": {
-                "name": "virt",
-                "stream": "rhel",
-                "profiles": {"rhel": ["default", "common"]},
-            },
-        }
-    ]
-
-
-@pytest.fixture(name="mock_search_rpms")
-def fixture_mock_search_rpms(requests_mock, mock_repo, search_rpms_response):
-    url = "/pulp/api/v2/repositories/{REPO_ID}/search/units/".format(
-        REPO_ID=mock_repo.id
-    )
-    requests_mock.register_uri("POST", url, json=search_rpms_response)
-
-
-@pytest.fixture(name="mock_search_modules")
-def fixture_mock_search_modules(requests_mock, mock_repo, search_modules_response):
-    url = "/pulp/api/v2/repositories/{REPO_ID}/search/units/".format(
-        REPO_ID=mock_repo.id
-    )
-    requests_mock.register_uri("POST", url, json=search_modules_response)
-
-
-@pytest.fixture(name="mock_search_module_defaults")
-def fixture_mock_search_module_defaults(
-    requests_mock, mock_repo, search_module_defaults_response
-):
-    url = "/pulp/api/v2/repositories/{REPO_ID}/search/units/".format(
-        REPO_ID=mock_repo.id
-    )
-    requests_mock.register_uri("POST", url, json=search_module_defaults_response)
-
-
-@pytest.fixture(name="mock_publish")
-def fixture_mock_publish(requests_mock, mock_repo, mock_response_for_async_req):
-    url = "/pulp/api/v2/repositories/{repo_id}/actions/publish/".format(
-        repo_id=mock_repo.id
-    )
-    requests_mock.register_uri("POST", url, json=mock_response_for_async_req)
 
 
 @pytest.fixture(name="mock_associate")
@@ -190,45 +124,6 @@ def test_unassociate_module_defaults(mock_pulp, mock_unassociate, mock_repo, moc
     task_ids = mock_pulp.unassociate_module_defaults(mock_repo, [mock_mdd])
     assert task_ids
     assert task_ids[0] == "foo_task_id"
-
-
-def test_search_rpms(mock_pulp, mock_search_rpms, mock_repo):
-    # pylint: disable=unused-argument
-    found_rpms = mock_pulp.search_rpms(mock_repo)
-    assert len(found_rpms) == 1
-    assert found_rpms[0].name == "foo-pkg"
-    assert found_rpms[0].filename == "foo-pkg.rpm"
-    assert found_rpms[0].sourcerpm == "foo-pkg.src.rpm"
-    assert found_rpms[0].is_modular is False
-
-
-@pytest.mark.parametrize("search_rpms_response", [0, 1, 2], indirect=True)
-def test_search_rpms_by_filename(
-    mock_pulp, mock_search_rpms, mock_repo, search_rpms_response
-):
-    # pylint: disable=unused-argument
-    found_rpms = mock_pulp.search_rpms(mock_repo, filename="foo-pkg.rpm")
-    assert len(search_rpms_response) == len(found_rpms)
-
-
-def test_search_modules(mock_pulp, mock_search_modules, mock_repo):
-    # pylint: disable=unused-argument
-    found_modules = mock_pulp.search_modules(mock_repo)
-    assert len(found_modules) == 1
-
-    assert found_modules[0].nsvca == "foo-module:9.6:1111:foo-context:x86_64"
-    assert found_modules[0].packages == ["foo-pkg"]
-    assert found_modules[0].profiles == {"foo-prof": ["pkg-name"]}
-
-
-def test_search_module_defaults(mock_pulp, mock_search_module_defaults, mock_repo):
-    # pylint: disable=unused-argument
-    found_module_defaults = mock_pulp.search_module_defaults(
-        mock_repo, name="virt", stream="rhel"
-    )
-    assert len(found_module_defaults) == 1
-    assert found_module_defaults[0].name == "virt"
-    assert found_module_defaults[0].stream == "rhel"
 
 
 @pytest.fixture(name="search_task_response")
@@ -279,24 +174,6 @@ def make_mock_response(status, text):
             True,
             500,
             None,
-            "search_rpms",
-            (MagicMock(id="fake_id"),),
-            "[]",
-            pulp_client.HTTP_TOTAL_RETRIES,
-        ),
-        (
-            True,
-            500,
-            None,
-            "search_modules",
-            (MagicMock(id="fake_id"),),
-            "[]",
-            pulp_client.HTTP_TOTAL_RETRIES,
-        ),
-        (
-            True,
-            500,
-            None,
             "wait_for_tasks",
             (["fake-tid"],),
             '{"state":"finished","task_id":"fake-tid"}',
@@ -335,9 +212,35 @@ def make_mock_response(status, text):
             pulp_client.HTTP_TOTAL_RETRIES,
         ),
         # test custom number of retries
-        (True, 500, 3, "search_rpms", (MagicMock(id="fake_id"),), "{}", 3),
+        (
+            True,
+            500,
+            3,
+            "associate_units",
+            (
+                MagicMock(id="fake_id"),
+                MagicMock(id="fake_id"),
+                MagicMock(),
+                ["rpm"],
+            ),
+            '{"spawned_tasks":[]}',
+            3,
+        ),
         # test 400 status is not retryable
-        (False, 400, 3, "search_rpms", (MagicMock(id="fake_id"),), "{}", 3),
+        (
+            False,
+            400,
+            3,
+            "associate_units",
+            (
+                MagicMock(id="fake_id"),
+                MagicMock(id="fake_id"),
+                MagicMock(),
+                ["rpm"],
+            ),
+            '{"spawned_tasks":[]}',
+            3,
+        ),
     ],
 )
 def test_retries(

--- a/ubipop/__init__.py
+++ b/ubipop/__init__.py
@@ -7,13 +7,13 @@ from concurrent.futures import as_completed
 from itertools import chain
 from pubtools.pulplib import Client, Criteria, PublishOptions
 
+import attr
 import ubiconfig
 
 from more_executors import Executors
 from more_executors.futures import f_sequence, f_proxy, f_return
-from ubipop._pulp_client import Pulp, Package
+from ubipop._pulp_client import Pulp
 from ubipop._utils import (
-    split_filename,
     AssociateActionModules,
     AssociateActionModuleDefaults,
     AssociateActionRpms,
@@ -22,7 +22,7 @@ from ubipop._utils import (
     UnassociateActionRpms,
     flatten_md_defaults_name_profiles,
 )
-from ._matcher import ModularMatcher, RpmMatcher
+from ._matcher import ModularMatcher, RpmMatcher, Matcher
 
 
 _LOG = logging.getLogger("ubipop")
@@ -41,6 +41,15 @@ class PopulationSourceMissing(Exception):
 
 
 RepoSet = namedtuple("RepoSet", ["rpm", "source", "debug"])
+
+
+@attr.s
+class RepoContent(object):
+    binary_rpms = attr.ib()
+    source_rpms = attr.ib()
+    debug_rpms = attr.ib()
+    modules = attr.ib()
+    modulemd_defaults = attr.ib()
 
 
 class UbiRepoSet(object):
@@ -426,11 +435,7 @@ class UbiPopulateRunner(object):
 
     def _get_pulp_actions(
         self,
-        current_modules_ft,
-        current_module_defaults_ft,
-        current_rpms_ft,
-        current_srpms_ft,
-        current_debug_rpms_ft,
+        current_content,
         modular_binary,
         modular_debug,
         modular_source,
@@ -445,24 +450,24 @@ class UbiPopulateRunner(object):
         """
 
         modules_assoc, modules_unassoc = self._get_pulp_actions_mds(
-            self.repos.modules, current_modules_ft.result()
+            self.repos.modules, current_content.modules
         )
         md_defaults_assoc, md_defaults_unassoc = self._get_pulp_actions_md_defaults(
-            self.repos.module_defaults, current_module_defaults_ft.result()
+            self.repos.module_defaults, current_content.modulemd_defaults
         )
 
         rpms_assoc, rpms_unassoc = self._get_pulp_actions_pkgs(
-            self.repos.packages, current_rpms_ft.result(), modular_binary
+            self.repos.packages, current_content.binary_rpms, modular_binary
         )
         srpms_assoc, srpms_unassoc = self._get_pulp_actions_src_pkgs(
-            self.repos.source_rpms, current_srpms_ft.result(), modular_source
+            self.repos.source_rpms, current_content.source_rpms, modular_source
         )
 
         debug_assoc = None
         debug_unassoc = None
-        if current_debug_rpms_ft is not None:
+        if current_content.debug_rpms:
             debug_assoc, debug_unassoc = self._get_pulp_actions_pkgs(
-                self.repos.debug_rpms, current_debug_rpms_ft.result(), modular_debug
+                self.repos.debug_rpms, current_content.debug_rpms, modular_debug
             )
 
         associations = (
@@ -520,14 +525,7 @@ class UbiPopulateRunner(object):
         return diff
 
     def run_ubi_population(self):
-        (
-            current_modules_ft,
-            current_module_defaults_ft,
-            current_rpms_ft,
-            current_srpms_ft,
-            current_debug_rpms_ft,
-        ) = self._get_current_content()
-
+        current_content = self._get_current_content()
         # start async querying for modulemds and modular and non-modular packages
         mm = ModularMatcher(self.repos.in_repos, self.ubiconfig.modules).run()
         rm = RpmMatcher(self.repos.in_repos, self.ubiconfig).run()
@@ -544,24 +542,14 @@ class UbiPopulateRunner(object):
             mdd_association,
             mdd_unassociation,
         ) = self._get_pulp_actions(
-            current_modules_ft,
-            current_module_defaults_ft,
-            current_rpms_ft,
-            current_srpms_ft,
-            current_debug_rpms_ft,
+            current_content,
             mm.binary_rpms,
             mm.debug_rpms,
             mm.source_rpms,
         )
 
         if self.dry_run:
-            self.log_curent_content(
-                current_modules_ft,
-                current_module_defaults_ft,
-                current_rpms_ft,
-                current_srpms_ft,
-                current_debug_rpms_ft,
-            )
+            self.log_curent_content(current_content)
             self.log_pulp_actions(
                 associations + (mdd_association,),
                 unassociations + (mdd_unassociation,),
@@ -607,33 +595,26 @@ class UbiPopulateRunner(object):
             if tasks:
                 self.pulp.wait_for_tasks(tasks)
 
-    def log_curent_content(
-        self,
-        current_modules_ft,
-        current_module_defaults_ft,
-        current_rpms_ft,
-        current_srpms_ft,
-        current_debug_rpms_ft,
-    ):
+    def log_curent_content(self, current_content):
         _LOG.info("Current modules in repo: %s", self.repos.out_repos.rpm.id)
-        for module in current_modules_ft.result():
+        for module in current_content.modules:
             _LOG.info(module.nsvca)
 
         _LOG.info("Current module_defaults in repo: %s", self.repos.out_repos.rpm.id)
-        for md_d in current_module_defaults_ft.result():
+        for md_d in current_content.modulemd_defaults:
             _LOG.info("module_defaults: %s, profiles: %s", md_d.name, md_d.profiles)
 
         _LOG.info("Current rpms in repo: %s", self.repos.out_repos.rpm.id)
-        for rpm in current_rpms_ft.result():
+        for rpm in current_content.binary_rpms:
             _LOG.info(rpm.filename)
 
         _LOG.info("Current srpms in repo: %s", self.repos.out_repos.source.id)
-        for rpm in current_srpms_ft.result():
+        for rpm in current_content.source_rpms:
             _LOG.info(rpm.filename)
 
         if self.repos.out_repos.debug:
             _LOG.info("Current rpms in repo: %s", self.repos.out_repos.debug.id)
-            for rpm in current_debug_rpms_ft.result():
+            for rpm in current_content.debug_rpms:
                 _LOG.info(rpm.filename)
 
     def log_pulp_actions(self, associations, unassociations):
@@ -670,32 +651,45 @@ class UbiPopulateRunner(object):
         """
         Gather current content of output repos
         """
-        current_modules_ft = self._executor.submit(
-            self.pulp.search_modules, self.repos.out_repos.rpm
+        criteria = [Criteria.true()]
+        current_modulemds = f_proxy(
+            self._executor.submit(
+                Matcher.search_modulemds, criteria, [self.repos.out_repos.rpm]
+            )
         )
-        current_module_defaults_ft = self._executor.submit(
-            self.pulp.search_module_defaults, self.repos.out_repos.rpm
+        current_modulemd_defaults = f_proxy(
+            self._executor.submit(
+                Matcher.search_modulemd_defaults, criteria, [self.repos.out_repos.rpm]
+            )
         )
-        current_rpms_ft = self._executor.submit(
-            self.pulp.search_rpms, self.repos.out_repos.rpm
+        current_rpms = f_proxy(
+            self._executor.submit(
+                Matcher.search_rpms, criteria, [self.repos.out_repos.rpm]
+            )
         )
-        current_srpms_ft = self._executor.submit(
-            self.pulp.search_rpms, self.repos.out_repos.source
+        current_srpms = f_proxy(
+            self._executor.submit(
+                Matcher.search_srpms, criteria, [self.repos.out_repos.source]
+            )
         )
-        if self.repos.out_repos.debug:
-            current_debug_rpms_ft = self._executor.submit(
-                self.pulp.search_rpms, self.repos.out_repos.debug
+
+        if self.repos.out_repos.debug.result():
+            current_debug_rpms = f_proxy(
+                self._executor.submit(
+                    Matcher.search_rpms, criteria, [self.repos.out_repos.debug]
+                )
             )
         else:
-            current_debug_rpms_ft = None
+            current_debug_rpms = f_proxy(f_return([]))
 
-        return (
-            current_modules_ft,
-            current_module_defaults_ft,
-            current_rpms_ft,
-            current_srpms_ft,
-            current_debug_rpms_ft,
+        current_content = RepoContent(
+            current_rpms,
+            current_srpms,
+            current_debug_rpms,
+            current_modulemds,
+            current_modulemd_defaults,
         )
+        return current_content
 
     def _publish_out_repos(self):
         fts = []

--- a/ubipop/_pulp_client.py
+++ b/ubipop/_pulp_client.py
@@ -4,7 +4,6 @@ import threading
 import time
 
 from urllib3.util.retry import Retry
-from ubipop._utils import split_filename
 
 try:
     from urllib.parse import urljoin
@@ -89,91 +88,6 @@ class Pulp(object):
             ret = None
 
         return ret
-
-    def search_rpms(
-        self, repo, name=None, arch=None, name_globbing=False, filename=None
-    ):
-        url = "repositories/{REPO_ID}/search/units/".format(REPO_ID=repo.id)
-        criteria = {"type_ids": ["rpm", "srpm"]}
-
-        filters = {"filters": {"unit": {}}}
-        if name:
-            if name_globbing:
-                filters["filters"]["unit"]["name"] = {"$regex": name + ".*"}
-            else:
-                filters["filters"]["unit"]["name"] = name
-
-        if arch:
-            filters["filters"]["unit"]["arch"] = arch
-
-        if filename:
-            filters["filters"]["unit"]["filename"] = filename
-
-        criteria.update(filters)
-        payload = {"criteria": criteria}
-        ret = self.do_request("post", url, payload)
-        rpms = []
-        ret.raise_for_status()
-        for item in ret.json():
-            metadata = item["metadata"]
-            rpms.append(
-                Package(
-                    metadata["name"],
-                    metadata["filename"],
-                    repo.id,
-                    sourcerpm_filename=metadata.get("sourcerpm"),
-                )
-            )
-        return rpms
-
-    def search_modules(self, repo, name=None, stream=None):
-        url = "repositories/{REPO_ID}/search/units/".format(REPO_ID=repo.id)
-        criteria = {"type_ids": ["modulemd"]}
-        if name and stream:
-            criteria.update({"filters": {"unit": {"name": name, "stream": stream}}})
-        payload = {"criteria": criteria}
-
-        ret = self.do_request("post", url, payload)
-        modules = []
-        ret.raise_for_status()
-        for item in ret.json():
-
-            metadata = item["metadata"]
-            modules.append(
-                Module(
-                    metadata["name"],
-                    metadata["stream"],
-                    metadata["version"],
-                    metadata["context"],
-                    metadata["arch"],
-                    metadata["artifacts"],
-                    metadata["profiles"],
-                    repo.id,
-                )
-            )
-        return modules
-
-    def search_module_defaults(self, repo, name=None, stream=None):
-        url = "repositories/{REPO_ID}/search/units/".format(REPO_ID=repo.id)
-        criteria = {"type_ids": ["modulemd_defaults"]}
-        if name and stream:
-            criteria.update({"filters": {"unit": {"name": name, "stream": stream}}})
-        payload = {"criteria": criteria}
-
-        ret = self.do_request("post", url, payload)
-        ret.raise_for_status()
-        module_defaults = []
-        for item in ret.json():
-            metadata = item["metadata"]
-            module_defaults.append(
-                ModuleDefaults(
-                    metadata["name"],
-                    metadata["stream"],
-                    metadata["profiles"],
-                    repo.id,
-                )
-            )
-        return module_defaults
 
     def wait_for_tasks(self, task_id_list, delay=5.0):
         results = {}
@@ -290,68 +204,3 @@ class Pulp(object):
 
     def unassociate_packages(self, repo, rpms):
         return self.unassociate_units(repo, rpms, ("rpm", "srpm"))
-
-
-class Package(object):
-    def __init__(
-        self, name, filename, src_repo_id, sourcerpm_filename=None, is_modular=False
-    ):
-        self.name = name
-        self.filename = filename
-        self.sourcerpm = sourcerpm_filename
-        self.is_modular = is_modular
-        #  return name, ver, rel, epoch, arch
-        _, self.version, self.release, self.epoch, _ = split_filename(self.filename)
-        self.associate_source_repo_id = src_repo_id
-
-    def __str__(self):
-        return self.filename
-
-
-class Module(object):
-    def __init__(
-        self, name, stream, version, context, arch, packages, profiles, src_repo_id
-    ):
-        self.name = name
-        self.stream = stream
-        self.version = version
-        self.context = context
-        self.arch = arch
-        self.packages = packages
-        self.profiles = profiles
-        self.associate_source_repo_id = src_repo_id
-
-    @property
-    def nsvca(self):
-        return ":".join(
-            (self.name, self.stream, str(self.version), self.context, self.arch)
-        )
-
-    def __str__(self):
-        return self.nsvca
-
-
-class ModuleDefaults(object):
-    """
-    module_defaults unit, defines which profiles are enabled by default when activating
-    a module. For example:
-    {...,
-     "name": "ruby",
-     "profiles": {
-        "2.5": [
-            "common"]
-        },
-    ...
-    }
-    if someone asks to enable 'ruby:2.5' for some repo without specifing profiles, will
-    get 'common' profile by defualt
-    """
-
-    def __init__(self, name, stream, profiles, src_repo_id):
-        self.name = name
-        self.stream = stream
-        self.profiles = profiles  # a dict such as {'4.046':['common']}
-        self.associate_source_repo_id = src_repo_id
-
-    def __str__(self):
-        return self.name


### PR DESCRIPTION
This comming includes refactoring of getting current content
of ubi repositories.
- Queries for getting content from ubi repos now re-uses code from
  Matcher class. Some private methods were made public and changed to
  class methods.
- All related queries located originally located in _pulp_client.py
  were removed also with model classes. It brings us closer to
  100% usage of pubtools-pulplib Client. Currently we still need to use
  only calls from _pulp_client.py for content un/association that are
  not ready in pubtools-pulplib at the time of creation of this commit.
- Added couple of helper methods for test and updated/add tests