### PR TITLE
ubipop indicate user populating a repo without ubi_config_version [RHELDST-8053]

### DIFF
--- a/tests/test_ubipop.py
+++ b/tests/test_ubipop.py
@@ -182,15 +182,32 @@ def test_raise_config_missing(caplog):
     ubipopulate = UbiPopulate(
         "foo.pulp.com", ("foo", "foo"), False, ubiconfig_dir_or_url=config_path
     )
-
+    repo = YumRepository(
+        id="repo",
+        ubi_config_version="9.8",
+    )
     for config in ubipopulate.ubiconfig_list:
         with pytest.raises(ConfigMissing):
-            ubipopulate._get_config("9.8", config)
+            ubipopulate._get_config(repo, config)
 
     assert (
         "Config file ubiconf_golang.yaml missing from 9.8 and default 9 branches"
         in caplog.text
     )
+
+
+def test_raise_error_for_missing_ubi_config_version():
+    config_path = os.path.join(TEST_DATA_DIR, "ubi8")
+    ubipopulate = UbiPopulate(
+        "foo.pulp.com", ("foo", "foo"), False, ubiconfig_dir_or_url=config_path
+    )
+    repo = YumRepository(
+        id="repo",
+        ubi_config_version="",
+    )
+    for config in ubipopulate.ubiconfig_list:
+        with pytest.raises(ValueError):
+            ubipopulate._get_config(repo, config)
 
 
 def test_publish_out_repos(mock_ubipop_runner):

--- a/ubipop/__init__.py
+++ b/ubipop/__init__.py
@@ -251,10 +251,13 @@ class UbiPopulate(object):
 
         return config_map
 
-    def _get_config(self, ubi_config_version, config):
+    def _get_config(self, repo, config):
         # get the right config file by ubi_config_version attr of a repository
         # if not found, try to fallback to the default version (major version)
-        _ubi_config_version = ubi_config_version
+        if not repo.ubi_config_version:
+            raise ValueError("Repo: %s does not have ubi_config_version" % repo.id)
+
+        _ubi_config_version = repo.ubi_config_version
         if _ubi_config_version not in self.ubiconfig_map:
             # if the config is missing, we need to use the default config branch
             _ubi_config_version = _ubi_config_version.split(".")[0]
@@ -264,8 +267,8 @@ class UbiPopulate(object):
             _LOG.error(
                 "Config file %s missing from %s and default %s branches",
                 config.file_name,
-                ubi_config_version,
-                ubi_config_version.split(".")[0],
+                repo.ubi_config_version,
+                repo.ubi_config_version.split(".")[0],
             )
             raise ConfigMissing()
 
@@ -305,9 +308,7 @@ class UbiPopulate(object):
                 continue
 
             for repo_set in repo_pairs:
-                right_config = self._get_config(
-                    repo_set.out_repos.rpm.ubi_config_version, config
-                )
+                right_config = self._get_config(repo_set.out_repos.rpm, config)
 
                 repos_publishes = UbiPopulateRunner(
                     self.pulp,


### PR DESCRIPTION
Check if ubi_config_version note info exists before calling _get_config(),
so it will not crash when ubi_config_version is empty.
And an ERROR level logger added.