### PR TITLE
Update tox cov job to generate xml coverage report

### DIFF
--- a/tests/test_ubipop.py
+++ b/tests/test_ubipop.py
@@ -987,11 +987,11 @@ def test_log_pulp_action(capsys, set_logging, mock_ubipop_runner):
     assert err == ""
     assert (
         assoc_line.strip()
-        == "Would associate ModulemdUnit(name='test_assoc', stream='fake-stream', version=1, context='fake-context', arch='x86_64', content_type_id='modulemd', repository_memberships=None, artifacts=None, profiles=None) from test_src to test_dst"
+        == "Would associate ModulemdUnit(name='test_assoc', stream='fake-stream', version=1, context='fake-context', arch='x86_64', content_type_id='modulemd', repository_memberships=None, unit_id=None, artifacts=None, profiles=None, dependencies=None) from test_src to test_dst"
     )
     assert (
         unassoc_line.strip()
-        == "Would unassociate ModulemdUnit(name='test_unassoc', stream='fake-stream', version=1, context='fake-context', arch='x86_64', content_type_id='modulemd', repository_memberships=None, artifacts=None, profiles=None) from test_dst"
+        == "Would unassociate ModulemdUnit(name='test_unassoc', stream='fake-stream', version=1, context='fake-context', arch='x86_64', content_type_id='modulemd', repository_memberships=None, unit_id=None, artifacts=None, profiles=None, dependencies=None) from test_dst"
     )
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -30,7 +30,7 @@ deps=
 	pytest-cov
 usedevelop=true
 commands=
-	pytest -v --cov-report=html --cov=ubipop {posargs}
+	pytest -v --cov-report=html --cov-report=xml --cov=ubipop {posargs}
 
 [testenv:cov-travis]
 passenv = TRAVIS TRAVIS_*


### PR DESCRIPTION
Codecov action to upload coverage report was upgraded to v2.
However, the reports were not uploaded correctly as v2 accepts
coverage reports in xml format only. Hence, updating the cov
job in tox to generate coverage reports in xml instead of html.