### PR TITLE
Integrate ubi-manifest [RHELDST-8706]

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -101,4 +101,6 @@ disable=print-statement,
         raise-missing-from,
         # skip check for non-snake_case names
         invalid-name,
+        # skip check for lambdas
+        unnecessary-lambda
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,2 @@
-black
+black==22.3.0
 pre-commit

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,19 @@
+import sys
 import pytest
 
 from pubtools.pulplib import RpmUnit, ModulemdUnit, ModulemdDefaultsUnit, FakeController
 from ubipop._matcher import UbiUnit
+
+if sys.version_info <= (
+    2,
+    7,
+):
+    import requests_mock as rm
+
+    @pytest.fixture(name="requests_mock")
+    def fixture_requests_mock():
+        with rm.Mocker() as m:
+            yield m
 
 
 def _get_test_unit(klass, **kwargs):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -46,7 +46,12 @@ def test_no_pulp_hostname(capsys):
     ],
 )
 def test_wrong_user_pass_cert_combination(capsys, auth_args):
-    args = ["--pulp-hostname", "foo.pulp.com"] + auth_args
+    args = [
+        "--pulp-hostname",
+        "foo.pulp.com",
+        "--ubi-manifest-url",
+        "https://ubi-manifest.com",
+    ] + auth_args
 
     with pytest.raises(SystemExit) as e_info:
         main(args)
@@ -58,7 +63,16 @@ def test_wrong_user_pass_cert_combination(capsys, auth_args):
 
 @mock.patch("ubipop.UbiPopulate")
 def test_default_config_source(mock_ubipopulate):
-    args = ["--pulp-hostname", "foo.pulp.com", "--user", "foo", "--pass", "foo"]
+    args = [
+        "--pulp-hostname",
+        "foo.pulp.com",
+        "--user",
+        "foo",
+        "--pass",
+        "foo",
+        "--ubi-manifest-url",
+        "https://ubi-manifest.com",
+    ]
     main(args)
     mock_ubipopulate.assert_called_once_with(
         "foo.pulp.com",
@@ -73,6 +87,7 @@ def test_default_config_source(mock_ubipopulate):
         repo_ids=None,
         version=None,
         content_set_regex=None,
+        ubi_manifest_url="https://ubi-manifest.com",
     )
 
 
@@ -87,6 +102,8 @@ def test_custom_config_source(mock_ubipopulate):
         "foo",
         "--conf-src",
         "custom/conf/dir",
+        "--ubi-manifest-url",
+        "https://ubi-manifest.com",
     ]
     main(args)
     mock_ubipopulate.assert_called_once_with(
@@ -102,6 +119,7 @@ def test_custom_config_source(mock_ubipopulate):
         repo_ids=None,
         version=None,
         content_set_regex=None,
+        ubi_manifest_url="https://ubi-manifest.com",
     )
 
 
@@ -114,6 +132,8 @@ def test_crt(mock_ubipopulate):
         "/cert.cert",
         "--conf-src",
         "custom/conf/dir",
+        "--ubi-manifest-url",
+        "https://ubi-manifest.com",
     ]
     main(args)
     mock_ubipopulate.assert_called_once_with(
@@ -129,6 +149,7 @@ def test_crt(mock_ubipopulate):
         repo_ids=None,
         version=None,
         content_set_regex=None,
+        ubi_manifest_url="https://ubi-manifest.com",
     )
 
 
@@ -145,6 +166,8 @@ def test_specified_filenames(mock_ubipopulate):
         "custom/conf/dir",
         "f1",
         "f2",
+        "--ubi-manifest-url",
+        "https://ubi-manifest.com",
     ]
     main(args)
     mock_ubipopulate.assert_called_once_with(
@@ -160,6 +183,7 @@ def test_specified_filenames(mock_ubipopulate):
         repo_ids=None,
         version=None,
         content_set_regex=None,
+        ubi_manifest_url="https://ubi-manifest.com",
     )
 
 
@@ -174,6 +198,8 @@ def test_specified_content_sets(mock_ubipopulate):
         "foo",
         "--content-sets",
         "test_repo1-rpms",
+        "--ubi-manifest-url",
+        "https://ubi-manifest.com",
     ]
     main(args)
     mock_ubipopulate.assert_called_once_with(
@@ -191,6 +217,7 @@ def test_specified_content_sets(mock_ubipopulate):
         repo_ids=None,
         version=None,
         content_set_regex=None,
+        ubi_manifest_url="https://ubi-manifest.com",
     )
 
 
@@ -205,6 +232,8 @@ def test_specified_repo_ids(mock_ubipopulate):
         "foo",
         "--repo-ids",
         "test_repo1",
+        "--ubi-manifest-url",
+        "https://ubi-manifest.com",
     ]
     main(args)
     mock_ubipopulate.assert_called_once_with(
@@ -222,6 +251,7 @@ def test_specified_repo_ids(mock_ubipopulate):
         ],
         version=None,
         content_set_regex=None,
+        ubi_manifest_url="https://ubi-manifest.com",
     )
 
 
@@ -239,6 +269,8 @@ def test_dry_run(mock_ubipopulate):
         "f1",
         "f2",
         "--dry-run",
+        "--ubi-manifest-url",
+        "https://ubi-manifest.com",
     ]
     main(args)
     mock_ubipopulate.assert_called_once_with(
@@ -254,6 +286,7 @@ def test_dry_run(mock_ubipopulate):
         repo_ids=None,
         version=None,
         content_set_regex=None,
+        ubi_manifest_url="https://ubi-manifest.com",
     )
 
 
@@ -272,6 +305,8 @@ def test_custom_workers_number(mock_ubipopulate):
         "f2",
         "--workers",
         "42",
+        "--ubi-manifest-url",
+        "https://ubi-manifest.com",
     ]
     main(args)
     mock_ubipopulate.assert_called_once_with(
@@ -287,6 +322,7 @@ def test_custom_workers_number(mock_ubipopulate):
         repo_ids=None,
         version=None,
         content_set_regex=None,
+        ubi_manifest_url="https://ubi-manifest.com",
     )
 
 
@@ -306,6 +342,8 @@ def test_insecure(mock_ubipopulate):
         "--workers",
         "42",
         "--insecure",
+        "--ubi-manifest-url",
+        "https://ubi-manifest.com",
     ]
     main(args)
     mock_ubipopulate.assert_called_once_with(
@@ -321,6 +359,7 @@ def test_insecure(mock_ubipopulate):
         repo_ids=None,
         version=None,
         content_set_regex=None,
+        ubi_manifest_url="https://ubi-manifest.com",
     )
 
 
@@ -335,6 +374,8 @@ def test_output_file(mock_ubipopulate):
         "foo",
         "--output-repos",
         "/foo/out/repos.txt",
+        "--ubi-manifest-url",
+        "https://ubi-manifest.com",
     ]
     main(args)
     mock_ubipopulate.assert_called_once_with(
@@ -350,6 +391,7 @@ def test_output_file(mock_ubipopulate):
         repo_ids=None,
         version=None,
         content_set_regex=None,
+        ubi_manifest_url="https://ubi-manifest.com",
     )
 
 
@@ -364,6 +406,8 @@ def test_version(mock_ubipopulate):
         "foo",
         "--version",
         "100",
+        "--ubi-manifest-url",
+        "https://ubi-manifest.com",
     ]
     main(args)
     mock_ubipopulate.assert_called_once_with(
@@ -379,6 +423,7 @@ def test_version(mock_ubipopulate):
         repo_ids=None,
         version="100",
         content_set_regex=None,
+        ubi_manifest_url="https://ubi-manifest.com",
     )
 
 
@@ -393,6 +438,8 @@ def test_content_set_regex(mock_ubipopulate):
         "foo",
         "--content-set-regex",
         "test-regex.*",
+        "--ubi-manifest-url",
+        "https://ubi-manifest.com",
     ]
     main(args)
     mock_ubipopulate.assert_called_once_with(
@@ -408,4 +455,5 @@ def test_content_set_regex(mock_ubipopulate):
         repo_ids=None,
         version=None,
         content_set_regex="test-regex.*",
+        ubi_manifest_url="https://ubi-manifest.com",
     )

--- a/tests/test_pulp.py
+++ b/tests/test_pulp.py
@@ -1,4 +1,3 @@
-import sys
 import threading
 
 try:
@@ -25,17 +24,6 @@ from .conftest import (
 
 ORIG_HTTP_TOTAL_RETRIES = pulp_client.HTTP_TOTAL_RETRIES
 ORIG_HTTP_RETRY_BACKOFF = pulp_client.HTTP_RETRY_BACKOFF
-
-if sys.version_info <= (
-    2,
-    7,
-):
-    import requests_mock as rm
-
-    @pytest.fixture(name="requests_mock")
-    def fixture_requests_mock():
-        with rm.Mocker() as m:
-            yield m
 
 
 @pytest.fixture(name="mock_pulp")

--- a/tests/test_ubi_manifest_client.py
+++ b/tests/test_ubi_manifest_client.py
@@ -1,0 +1,149 @@
+import os
+from mock import MagicMock
+
+import pytest
+
+from ubipop.ubi_manifest_client.client import Client, UbiManifestTaskFailure
+from ubipop.ubi_manifest_client.models import (
+    ModulemdDefaultsUnit,
+    ModulemdUnit,
+    RpmUnit,
+    UbiManifest,
+)
+
+
+def test_generate_manifest(requests_mock):
+    url = "api/v1/manifest"
+    url = os.path.join("https://foo-bar.com", url)
+
+    response = [{"task_id": "some-task-id"}]
+    requests_mock.register_uri("POST", url, json=response)
+
+    url = "api/v1/task/some-task-id"
+
+    url = os.path.join("https://foo-bar.com", url)
+    requests_mock.register_uri(
+        "GET",
+        url,
+        [
+            {
+                "json": {"task_id": "some-task-id", "state": "PENDING"},
+                "status_code": 200,
+            },
+            {
+                "json": {"task_id": "some-task-id", "state": "SUCCESS"},
+                "status_code": 200,
+            },
+        ],
+    )
+
+    with Client("https://foo-bar.com") as client:
+
+        tasks = client.generate_manifest(["repo_id_1", "repo_id_2"])
+        tasks.result()
+
+
+def test_generate_manifest_failure(requests_mock):
+    url = "api/v1/manifest"
+    url = os.path.join("https://foo-bar.com", url)
+
+    response = [{"task_id": "some-task-id"}]
+    requests_mock.register_uri("POST", url, json=response)
+
+    url = "api/v1/task/some-task-id"
+
+    url = os.path.join("https://foo-bar.com", url)
+    requests_mock.register_uri(
+        "GET",
+        url,
+        [
+            {
+                "json": {"task_id": "some-task-id", "state": "PENDING"},
+                "status_code": 200,
+            },
+            {
+                "json": {"task_id": "some-task-id", "state": "FAILURE"},
+                "status_code": 200,
+            },
+        ],
+    )
+
+    with Client("https://foo-bar.com") as client:
+        tasks = client.generate_manifest(["repo_id_1", "repo_id_2"])
+        with pytest.raises(UbiManifestTaskFailure):
+            tasks.result()
+
+
+def test_unpack_failure():
+    with Client("https://foo-bar.com") as client:
+        response = MagicMock()
+        response.json.side_effect = Exception()
+        with pytest.raises(Exception):
+            client._unpack_response(response)
+
+
+def test_get_manifest(requests_mock):
+    url = "api/v1/manifest/some-repo-id"
+    url = os.path.join("https://foo-bar.com", url)
+
+    response = {
+        "repo_id": "some-repo-id",
+        "content": [
+            {
+                "unit_type": "RpmUnit",
+                "src_repo_id": "another-repo-id",
+                "value": "some_package.rpm",
+            },
+            {
+                "unit_type": "ModulemdUnit",
+                "src_repo_id": "another-repo-id",
+                "value": "name:stream:version:context:arch",
+            },
+            {
+                "unit_type": "ModulemdDefaultsUnit",
+                "src_repo_id": "another-repo-id",
+                "value": "name:stream",
+            },
+        ],
+    }
+
+    requests_mock.register_uri("GET", url, json=response)
+
+    with Client("https://foo-bar.com") as client:
+        manifest = client.get_manifest("some-repo-id").result()
+
+        assert isinstance(manifest, UbiManifest)
+        assert manifest.repo_id == "some-repo-id"
+
+        # there should 3 units in the manifest
+        assert len(manifest.manifest) == 3
+
+        sorted_units = sorted(manifest.manifest, key=lambda x: x.src_repo_id)
+
+        # each unit has proper type and fields set
+        unit = sorted_units[0]
+        assert isinstance(unit, RpmUnit)
+        assert unit.src_repo_id == "another-repo-id"
+        assert unit.associate_source_repo_id == unit.src_repo_id
+
+        assert unit.dst_repo_id == "some-repo-id"
+        assert unit.filename == "some_package.rpm"
+
+        unit = sorted_units[1]
+        assert isinstance(unit, ModulemdUnit)
+        assert unit.src_repo_id == "another-repo-id"
+        assert unit.associate_source_repo_id == unit.src_repo_id
+        assert unit.dst_repo_id == "some-repo-id"
+        assert unit.name == "name"
+        assert unit.stream == "stream"
+        assert unit.version == "version"
+        assert unit.context == "context"
+        assert unit.arch == "arch"
+
+        unit = sorted_units[2]
+        assert isinstance(unit, ModulemdDefaultsUnit)
+        assert unit.src_repo_id == "another-repo-id"
+        assert unit.associate_source_repo_id == unit.src_repo_id
+        assert unit.dst_repo_id == "some-repo-id"
+        assert unit.name == "name"
+        assert unit.stream == "stream"

--- a/tox.ini
+++ b/tox.ini
@@ -17,7 +17,7 @@ whitelist_externals=yum
 [testenv:static]
 deps=
 	-rtest-requirements.txt
-	black==21.5b2
+	black==22.3.0
 	pylint==2.8.3
 
 commands=

--- a/ubipop/cli.py
+++ b/ubipop/cli.py
@@ -86,6 +86,12 @@ def parse_args(args):
         required=False,
         help="Regular expression of ubi content set to be populated.",
     )
+    parser.add_argument(
+        "--ubi-manifest-url",
+        action="store",
+        required=True,
+        help="URL of ubi-manifest service",
+    )
 
     parsed = parser.parse_args(args)
 
@@ -124,6 +130,7 @@ def main(args):
         repo_ids=opts.repo_ids,
         version=opts.version,
         content_set_regex=opts.content_set_regex,
+        ubi_manifest_url=opts.ubi_manifest_url,
     ).populate_ubi_repos()
 
 

--- a/ubipop/ubi_manifest_client/client.py
+++ b/ubipop/ubi_manifest_client/client.py
@@ -1,0 +1,125 @@
+import logging
+import os
+import threading
+from concurrent.futures import as_completed
+
+import requests
+from more_executors import Executors, f_map, f_proxy
+
+from .models import UbiManifest
+
+LOG = logging.getLogger(__name__)
+
+API = "api/v1"
+
+
+REQUESTS_MAX_WORKERS = int(os.getenv("UBIPOP_REQUESTS_MAX_WORKERS", "4"))
+
+
+class UbiManifestTaskFailure(Exception):
+    pass
+
+
+class Client(object):
+    def __init__(self, url):
+        self._url = os.path.join(url, API)
+        self._tls = threading.local()
+        self._executor = (
+            Executors.thread_pool(max_workers=REQUESTS_MAX_WORKERS)
+            .with_map(self._unpack_response)
+            .with_retry()
+        )
+        self._task_executor = (
+            Executors.thread_pool(max_workers=REQUESTS_MAX_WORKERS)
+            .with_map(self._unpack_response)
+            .with_map(self._log_spawned_tasks)
+            .with_poll(self._poll_tasks)
+            .with_retry()
+        )
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args, **kwargs):
+        self._executor.__exit__(*args, **kwargs)
+        self._task_executor.__exit__(*args, **kwargs)
+
+    def _unpack_response(self, response):
+        try:
+            out = response.json()
+        except Exception:
+            response.raise_for_status()
+            raise
+
+        response.raise_for_status()
+        return out
+
+    @property
+    def _session(self):
+        if not hasattr(self._tls, "session"):
+            self._tls.session = requests.Session()
+        return self._tls.session
+
+    def _do_request(self, **kwargs):
+        return self._session.request(**kwargs)
+
+    def get_manifest(self, repo_id):
+        endpoint = "manifest"
+        url = os.path.join(self._url, endpoint, repo_id)
+        LOG.debug("Getting manifest for %s", repo_id)
+        manifest_ft = self._executor.submit(self._do_request, method="GET", url=url)
+
+        return f_proxy(f_map(manifest_ft, lambda data: UbiManifest.from_data(data)))
+
+    def _get_task(self, task_id):
+        endpoint = "task"
+        url = os.path.join(self._url, endpoint, task_id)
+        LOG.debug("Getting state of task: %s", task_id)
+        return self._executor.submit(self._do_request, method="GET", url=url)
+
+    def generate_manifest(self, repo_ids):
+        endpoint = "manifest"
+        url = os.path.join(self._url, endpoint)
+
+        request_body = {"repo_ids": repo_ids}
+        LOG.debug("Requesting generation of manifest for %s", repo_ids)
+        return self._task_executor.submit(
+            self._do_request, method="POST", url=url, json=request_body
+        )
+
+    def _poll_tasks(self, poll_descriptors):
+        task_ids = []
+
+        for d in poll_descriptors:
+            for task in d.result:
+                task_ids.append(task.get("task_id"))
+
+        fts = []
+
+        for task_id in task_ids:
+            fts.append(self._get_task(task_id))
+
+        tasks = {}
+        for ft in as_completed(fts):
+            task = ft.result()
+            tasks[task["task_id"]] = task["state"]
+
+        for d in poll_descriptors:
+            succesfull_tasks = []
+            for task in d.result:
+                state = tasks.get(task["task_id"])
+                if state == "FAILURE":
+                    d.yield_exception(UbiManifestTaskFailure())
+                elif state == "SUCCESS":
+                    succesfull_tasks.append(task)
+
+            if len(succesfull_tasks) == len(d.result):
+                d.yield_result(succesfull_tasks)
+
+    def _log_spawned_tasks(self, task_data):
+        for item in task_data:
+            task_id = item.get("task_id")
+            if task_id:
+                LOG.info("Created ubi-manifest task: %s", task_id)
+
+        return task_data

--- a/ubipop/ubi_manifest_client/models.py
+++ b/ubipop/ubi_manifest_client/models.py
@@ -1,0 +1,102 @@
+import attr
+
+
+@attr.s
+class UbiManifest(object):
+    repo_id = attr.ib()
+    manifest = attr.ib()
+
+    @classmethod
+    def from_data(cls, data):
+        repo_id = data["repo_id"]
+        items = []
+        for item in data["content"]:
+            new_item = cls.make_ubi_unit(item, repo_id)
+            if new_item:
+                items.append(new_item)
+
+        return cls(repo_id=repo_id, manifest=items)
+
+    @staticmethod
+    def make_ubi_unit(manifest_item, dst_repo_id):
+        out = None
+
+        unit_type = manifest_item["unit_type"]
+        src_repo_id = manifest_item["src_repo_id"]
+        value = manifest_item["value"]
+
+        if unit_type == "RpmUnit":
+            out = RpmUnit(src_repo_id, dst_repo_id, value)
+        elif unit_type == "ModulemdUnit":
+            out = ModulemdUnit.from_nsvca(value, src_repo_id, dst_repo_id)
+        elif unit_type == "ModulemdDefaultsUnit":
+            out = ModulemdDefaultsUnit.from_ns(value, src_repo_id, dst_repo_id)
+        else:
+            # unknown unit
+            pass
+
+        return out
+
+    @property
+    def packages(self):
+        return self._filter_units_by_class(RpmUnit)
+
+    @property
+    def modules(self):
+        return self._filter_units_by_class(ModulemdUnit)
+
+    @property
+    def modulemd_defaults(self):
+        return self._filter_units_by_class(ModulemdDefaultsUnit)
+
+    def _filter_units_by_class(self, klass):
+        return [unit for unit in self.manifest if isinstance(unit, klass)]
+
+
+@attr.s
+class UbiCompatibleUnit(object):
+    src_repo_id = attr.ib()
+    dst_repo_id = attr.ib()
+
+    @property
+    def associate_source_repo_id(self):
+        return self.src_repo_id
+
+
+@attr.s
+class RpmUnit(UbiCompatibleUnit):
+    filename = attr.ib()
+
+
+@attr.s
+class ModulemdUnit(UbiCompatibleUnit):
+    name = attr.ib()
+    stream = attr.ib()
+    version = attr.ib()
+    context = attr.ib()
+    arch = attr.ib()
+
+    @classmethod
+    def from_nsvca(cls, nsvca, src_repo_id, dst_repo_id):
+        n, s, v, c, a = nsvca.split(":")
+        return cls(
+            name=n,
+            stream=s,
+            version=v,
+            context=c,
+            arch=a,
+            src_repo_id=src_repo_id,
+            dst_repo_id=dst_repo_id,
+        )
+
+
+@attr.s
+class ModulemdDefaultsUnit(UbiCompatibleUnit):
+    name = attr.ib()
+    stream = attr.ib()
+
+    @classmethod
+    def from_ns(cls, ns, src_repo_id, dst_repo_id):
+        n, s = ns.split(":")
+
+        return cls(name=n, stream=s, src_repo_id=src_repo_id, dst_repo_id=dst_repo_id)


### PR DESCRIPTION
This change introduces uasge of ubi-manifest that provides
manifests of final content of ubi repos. Following
is included in this changed:
* implemented a simple client for ubi-manifest servivce with task poller
* integrated usage of ubi-manifests in the ubipop workflow
* added required cli option --ubi-manifest-url
* tests were updated

There is still old unused code - it will be cleaned in subsequent
PRs.