### PR TITLE
Fix handling modular units

### DIFF
--- a/tests/test_matcher.py
+++ b/tests/test_matcher.py
@@ -87,7 +87,7 @@ def test_search_units(pulp):
     pulp.insert_units(repo, [unit_1, unit_2])
 
     matcher = Matcher(None, None)
-    criteria = matcher._create_or_criteria(["name", "arch"], [("test", "x86_64")])
+    criteria = matcher.create_or_criteria(["name", "arch"], [("test", "x86_64")])
     # let Future return result
     search_result = matcher._search_units(repo, criteria, "rpm").result()
 
@@ -113,7 +113,7 @@ def test_create_criteria():
     fields = ["color", "size"]
     values = [("blue", "10"), ("white", "15")]
 
-    criteria = matcher._create_or_criteria(fields, values)
+    criteria = matcher.create_or_criteria(fields, values)
 
     # there should be 2 criteria created
     assert len(criteria) == 2
@@ -129,10 +129,10 @@ def test_create_criteria_uneven_args():
 
     fields = ["color", "size"]
     values = [("blue", "10"), ("white")]
-    # call to _create_or_criteria raises ValueError because of uneven number of values of the second tuple
+    # call to create_or_criteria raises ValueError because of uneven number of values of the second tuple
     # in value list
     with pytest.raises(ValueError):
-        _ = matcher._create_or_criteria(fields, values)
+        _ = matcher.create_or_criteria(fields, values)
 
 
 def test_search_units_per_repos(pulp):
@@ -158,7 +158,7 @@ def test_search_units_per_repos(pulp):
     expected_repo_ids = ["test_repo_1", "test_repo_2"]
     matcher = Matcher(None, None)
 
-    criteria = matcher._create_or_criteria(
+    criteria = matcher.create_or_criteria(
         ["name", "arch"], [("test", "x86_64"), ("test", "i386")]
     )
 
@@ -199,7 +199,7 @@ def test_search_rpms(pulp):
     pulp.insert_units(repo, [unit_1, unit_2])
 
     matcher = Matcher(None, None)
-    criteria = matcher._create_or_criteria(["filename"], [("test.x86_64.rpm",)])
+    criteria = matcher.create_or_criteria(["filename"], [("test.x86_64.rpm",)])
     # let Future return result
     result = matcher.search_rpms(criteria, [repo]).result()
     # there should be be only one unit in the result set according to criteria
@@ -234,7 +234,7 @@ def test_search_srpms(pulp):
     pulp.insert_units(repo, [unit_1, unit_2])
 
     matcher = Matcher(None, None)
-    criteria = matcher._create_or_criteria(["filename"], [("test.src.rpm",)])
+    criteria = matcher.create_or_criteria(["filename"], [("test.src.rpm",)])
     # let Future return result
     result = matcher.search_srpms(criteria, [repo]).result()
     # there should be be only one unit in the result set according to criteria
@@ -267,7 +267,7 @@ def test_search_moludemds(pulp):
     pulp.insert_units(repo, [unit_1, unit_2])
 
     matcher = Matcher(None, None)
-    criteria = matcher._create_or_criteria(["name", "stream"], [("test", "10")])
+    criteria = matcher.create_or_criteria(["name", "stream"], [("test", "10")])
     # let Future return result
     result = matcher.search_modulemds(criteria, [repo]).result()
     # there should be be only one unit in the result set according to criteria
@@ -292,7 +292,7 @@ def test_search_moludemd_defaults(pulp):
     pulp.insert_units(repo, [unit_1])
 
     matcher = Matcher(None, None)
-    criteria = matcher._create_or_criteria(["name", "stream"], [("test", "10")])
+    criteria = matcher.create_or_criteria(["name", "stream"], [("test", "10")])
     # let Future return result
     result = matcher.search_modulemd_defaults(criteria, [repo]).result()
     # there should be be only one unit in the result set according to criteria

--- a/tests/test_ubipop.py
+++ b/tests/test_ubipop.py
@@ -1319,8 +1319,32 @@ def test_populate_ubi_repos(get_debug_repository, get_source_repository, request
         sourcerpm="golang-2.a.x86_64.src.rpm",
     )
 
-    fake_pulp.insert_units(output_binary_repo, [old_rpm])
-    fake_pulp.insert_units(input_binary_repo, [new_rpm])
+    old_modulemd = ModulemdUnit(
+        name="test_md", stream="s", version="100", context="c", arch="x86_64"
+    )
+    new_modulemd = ModulemdUnit(
+        name="test_md", stream="s", version="200", context="c", arch="x86_64"
+    )
+
+    old_modulemd_defaults = ModulemdDefaultsUnit(
+        name="test_md_defaults",
+        stream="stream",
+        profiles={"minimal": ["name_1"]},
+        repo_id="ubi_binary",
+    )
+    new_modulemd_defaults = ModulemdDefaultsUnit(
+        name="test_md_defaults",
+        stream="stream",
+        profiles={"minimal": ["name_1", "name_2"]},
+        repo_id="input_binary",
+    )
+
+    fake_pulp.insert_units(
+        output_binary_repo, [old_rpm, old_modulemd, old_modulemd_defaults]
+    )
+    fake_pulp.insert_units(
+        input_binary_repo, [new_rpm, new_modulemd, new_modulemd_defaults]
+    )
 
     url = "/pulp/api/v2/repositories/{dst_repo}/actions/associate/".format(
         dst_repo="ubi_binary"
@@ -1392,6 +1416,16 @@ def _create_ubi_manifest_mocks(requests_mock):
                 "unit_type": "RpmUnit",
                 "src_repo_id": "input_binary",
                 "value": "golang-2.a.x86_64.rpm",
+            },
+            {
+                "unit_type": "ModulemdUnit",
+                "src_repo_id": "input_binary",
+                "value": "test_md:s:200:c:x86_64",
+            },
+            {
+                "unit_type": "ModulemdDefaultsUnit",
+                "src_repo_id": "input_binary",
+                "value": "test_md_defaults:stream",
             },
         ],
     }

--- a/ubipop/__init__.py
+++ b/ubipop/__init__.py
@@ -562,6 +562,16 @@ class UbiPopulateRunner(object):
 
         return diff
 
+    def _search_expected_modulemd_defaults(self, modulemd_defaults):
+        criteria_values = [(unit.name,) for unit in modulemd_defaults]
+        fields = ("name",)
+        or_criteria = Matcher.create_or_criteria(fields, criteria_values)
+        return f_proxy(
+            self._executor.submit(
+                Matcher.search_modulemd_defaults, or_criteria, self.repos.in_repos.rpm
+            )
+        )
+
     def run_ubi_population(self):
         current_content = self._get_current_content()
 
@@ -579,7 +589,9 @@ class UbiPopulateRunner(object):
                 self.repos.out_repos.source.id
             )
             self.repos.modules = binary_manifest.modules
-            self.repos.module_defaults = binary_manifest.modulemd_defaults
+            self.repos.module_defaults = self._search_expected_modulemd_defaults(
+                binary_manifest.modulemd_defaults
+            )
             self.repos.packages = binary_manifest.packages
             self.repos.debug_rpms = debug_manifest.packages
             self.repos.source_rpms = source_manifest.packages

--- a/ubipop/_matcher.py
+++ b/ubipop/_matcher.py
@@ -103,7 +103,8 @@ class Matcher(object):
 
         return f_flat_map(f_sequence(fts), flatten_list_of_sets)
 
-    def _create_or_criteria(self, fields, values):
+    @classmethod
+    def create_or_criteria(cls, fields, values):
         # fields - list/tuple of fields [field1, field2]
         # values - list of tuples [(field1 value, field2 value), ...]
         # creates criteria for pulp query in a following way
@@ -184,7 +185,7 @@ class Matcher(object):
                     continue
                 filenames.append((pkg.sourcerpm,))
 
-        pkgs_or_criteria = self._create_or_criteria(("filename",), filenames)
+        pkgs_or_criteria = self.create_or_criteria(("filename",), filenames)
         return pkgs_or_criteria
 
 
@@ -254,7 +255,7 @@ class ModularMatcher(Matcher):
     def _get_modular_rpms_criteria(self):
         filenames_to_search = self._modular_rpms_filenames(self.modules)
         filenames_to_search = [(filename,) for filename in filenames_to_search]
-        pkgs_or_criteria = self._create_or_criteria(("filename",), filenames_to_search)
+        pkgs_or_criteria = self.create_or_criteria(("filename",), filenames_to_search)
         return pkgs_or_criteria
 
     def _get_modulemds_criteria(self):
@@ -274,7 +275,7 @@ class ModularMatcher(Matcher):
             )
 
         fields = ("name", "stream")
-        or_criteria = self._create_or_criteria(fields, criteria_values)
+        or_criteria = self.create_or_criteria(fields, criteria_values)
         return or_criteria
 
     def _get_modulemd_output_set(self, modules):
@@ -426,7 +427,7 @@ class RpmMatcher(Matcher):
             criteria_values.append((package_pattern.name, arch))
 
         fields = ("name", "arch")
-        or_criteria = self._create_or_criteria(fields, criteria_values)
+        or_criteria = self.create_or_criteria(fields, criteria_values)
         return or_criteria
 
     def _get_pkgs_from_all_modules(self):

--- a/ubipop/ubi_manifest_client/models.py
+++ b/ubipop/ubi_manifest_client/models.py
@@ -89,6 +89,12 @@ class ModulemdUnit(UbiCompatibleUnit):
             dst_repo_id=dst_repo_id,
         )
 
+    @property
+    def nsvca(self):
+        return ":".join(
+            (self.name, self.stream, str(self.version), self.context, self.arch)
+        )
+
 
 @attr.s
 class ModulemdDefaultsUnit(UbiCompatibleUnit):


### PR DESCRIPTION
- added missing nsvca property for ModulemdUnit model class
- added extra search for modulemd_defaults units
-- for association or unassociation actions they are diffed by profiles
   so we need to get this info from pulp. Name or stream is not enough.