### PR TITLE
Fixed ModulemdUnit model class

### DIFF
--- a/tests/test_ubi_manifest_client.py
+++ b/tests/test_ubi_manifest_client.py
@@ -97,7 +97,7 @@ def test_get_manifest(requests_mock):
             {
                 "unit_type": "ModulemdUnit",
                 "src_repo_id": "another-repo-id",
-                "value": "name:stream:version:context:arch",
+                "value": "name:stream:1234567890:context:arch",
             },
             {
                 "unit_type": "ModulemdDefaultsUnit",
@@ -136,7 +136,7 @@ def test_get_manifest(requests_mock):
         assert unit.dst_repo_id == "some-repo-id"
         assert unit.name == "name"
         assert unit.stream == "stream"
-        assert unit.version == "version"
+        assert unit.version == 1234567890
         assert unit.context == "context"
         assert unit.arch == "arch"
 

--- a/ubipop/ubi_manifest_client/models.py
+++ b/ubipop/ubi_manifest_client/models.py
@@ -82,7 +82,7 @@ class ModulemdUnit(UbiCompatibleUnit):
         return cls(
             name=n,
             stream=s,
-            version=v,
+            version=int(v),
             context=c,
             arch=a,
             src_repo_id=src_repo_id,


### PR DESCRIPTION
Attribute version on ModulemdUnit class has to be stored as integer,
otherwise any queries on pulp will not work as expected.