### PR TITLE
Fix packages lookup in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from setuptools import setup
+from setuptools import setup, find_packages
 
 
 def get_description():
@@ -40,7 +40,7 @@ setup(
     ],
     url="https://github.com/release-engineering/ubi-population-tool",
     install_requires=get_requirements(),
-    packages=["ubipop"],
+    packages=find_packages(exclude=["tests", "tests.*"]),
     entry_points={
         "console_scripts": [
             "ubipop = ubipop.cli:entry_point",


### PR DESCRIPTION
It wasn't possible to import ubi_manifest_client package,
let's add proper lookup into setup.py in order to include
the package.