### PR TITLE
Fixup: still dumps exception instead of simple log

### DIFF
--- a/tests/test_ubipop.py
+++ b/tests/test_ubipop.py
@@ -31,7 +31,6 @@ from ubipop import (
     UbiPopulate,
     ConfigMissing,
     RepoMissing,
-    PopulationSourceMissing,
 )
 from ubipop._utils import (
     AssociateActionModules,
@@ -283,10 +282,9 @@ def test_get_population_sources_empty():
         "foo.pulp.com", ("foo", "foo"), False, ubiconfig_dir_or_url=TEST_DATA_DIR
     )
 
-    with pytest.raises(PopulationSourceMissing):
-        fake_ubipopulate._get_population_sources(
-            repo
-        )  # pylint: disable=protected-access
+    assert (
+        fake_ubipopulate._get_population_sources(repo) == []
+    )  # pylint: disable=protected-access
 
 
 def test_get_population_sources_none():
@@ -294,10 +292,9 @@ def test_get_population_sources_none():
         "foo.pulp.com", ("foo", "foo"), False, ubiconfig_dir_or_url=TEST_DATA_DIR
     )
 
-    with pytest.raises(PopulationSourceMissing):
-        fake_ubipopulate._get_population_sources(
-            None
-        )  # pylint: disable=protected-access
+    assert (
+        fake_ubipopulate._get_population_sources(None) == []
+    )  # pylint: disable=protected-access
 
 
 @patch("pubtools.pulplib.YumRepository.get_debug_repository")

--- a/ubipop/__init__.py
+++ b/ubipop/__init__.py
@@ -425,7 +425,7 @@ class UbiPopulate(object):
             not hasattr(out_repo, "population_sources")
             or not out_repo.population_sources
         ):
-            raise PopulationSourceMissing
+            return []
 
         repos = [
             self.pulp_client.get_repository(repo_id)


### PR DESCRIPTION
The main issue was resolved, in that we were trying to access a value which wasn't present. However, we should return None and allow the UbiRepoSet class to raise a RepoMissing exception,  which is already captured and logged.
