### PR TITLE
Use specific ubuntu for py27 tests

### DIFF
--- a/.github/workflows/tox-test.yml
+++ b/.github/workflows/tox-test.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   py27:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
       - name: Install RPM


### PR DESCRIPTION
The py2.7 stopped working for GH actions on the latest
ubuntu, let's use the older one where py27 still is offered.