### PR TITLE
Drop rpm-py-installer from requirements.txt

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           python-version: 3.9
       - name: Install Tox
-        run: pip install tox 'virtualenv<20.21.1'
+        run: pip install tox
       - name: Run Tox
         run: |
           tox -e docs

--- a/.github/workflows/tox-test.yml
+++ b/.github/workflows/tox-test.yml
@@ -7,63 +7,48 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Install RPM
-        run: |
-          sudo apt-get install -y rpm
-          sudo apt-get install -y libkrb5-dev
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
           python-version: 3.8
       - name: Install Tox
-        run: pip install tox 'virtualenv<20.21.1'
+        run: pip install tox
       - name: Run Tox
         run: tox -e py38
   py39:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Install RPM
-        run: |
-          sudo apt-get install -y rpm
-          sudo apt-get install -y libkrb5-dev
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
           python-version: 3.9
       - name: Install Tox
-        run: pip install tox 'virtualenv<20.21.1'
+        run: pip install tox
       - name: Run Tox
         run: tox -e py39
   static:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Install RPM
-        run: |
-          sudo apt-get install -y rpm
-          sudo apt-get install -y libkrb5-dev
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
           python-version: 3.9
       - name: Install Tox
-        run: pip install tox 'virtualenv<20.21.1'
+        run: pip install tox
       - name: Run Tox
         run: tox -e static
   coverage:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Install RPM
-        run: |
-          sudo apt-get install -y rpm
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
           python-version: 3.9
       - name: Install Tox
-        run: pip install tox 'virtualenv<20.21.1'
+        run: pip install tox
       - name: Run Tox
         run: tox -e cov
       - name: Install pytest cov

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 requests
 more-executors>2.1.0
 ubi-config>=2.2.0
-rpm-py-installer
 pyrsistent
 pubtools-pulplib>=2.34.2
 attrs


### PR DESCRIPTION
The rpm-py-installer is no longer needed for this project, as the related code was moved to ubi-manifest project.

Let's drop the rpm-py-installer from requirements.txt now. Dropping also installation of rpm and other pkgs for CI.

This also fixes problems with rpm-py-installer installation on test environments.