### PR TITLE
Use urllib3 < 2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ pyrsistent
 pubtools-pulplib>=2.34.2
 attrs
 fastpurge
+urllib3<2


### PR DESCRIPTION
In the latest release of urllib3 there were some backwards incompatible changes released. Let's stick to urllib3 < 2 for the time being.

The affected code will likely be refactored or removed soon.