### PR TITLE
Fix tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,11 @@ commands=
 whitelist_externals=sh
 
 [testenv:integration]
-passenv = TEST_PULP_*, REQUESTS_CA_BUNDLE, TEST_MANIFEST_URL, GITLAB_CONFIG_URL
+passenv =
+	TEST_PULP_*
+	REQUESTS_CA_BUNDLE
+	TEST_MANIFEST_URL
+	GITLAB_CONFIG_URL
 deps=-rtest-requirements.txt
 commands=
         pytest -v {posargs} tests/integration


### PR DESCRIPTION
On older tox versions, passenv doesn't work with passenv variables specified inline with separator (,).