### PR TITLE
Add PKI support for pulp auth [RHELDST-18033]

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -37,7 +37,20 @@ def test_no_pulp_hostname(capsys):
 @pytest.mark.parametrize(
     "auth_args",
     [
-        (["--user", "foo", "--pass", "foo", "--cert", "foo/cert.cert"]),
+        (
+            [
+                "--user",
+                "foo",
+                "--pass",
+                "foo",
+                "--cert",
+                "foo/cert.cert",
+                "--key",
+                "foo/cert.key",
+            ]
+        ),
+        (["--user", "foo", "--key", "foo/cert.key"]),
+        (["--pass", "foo", "--cert", "foo/cert.cert"]),
         (["--pass", "foo", "--cert", "foo/cert.cert"]),
         (["--user", "foo", "--cert", "foo/cert.cert"]),
         (["--user", "foo"]),
@@ -57,7 +70,7 @@ def test_wrong_user_pass_cert_combination(capsys, auth_args):
         main(args)
 
     _, err = capsys.readouterr()
-    assert "Provide --user and --password options or --cert" in err
+    assert "Provide --user and --password options or --cert and --key" in err
     assert e_info.value.code == 2
 
 
@@ -130,6 +143,8 @@ def test_crt(mock_ubipopulate):
         "foo.pulp.com",
         "--cert",
         "/cert.cert",
+        "--key",
+        "/cert.key",
         "--conf-src",
         "custom/conf/dir",
         "--ubi-manifest-url",
@@ -138,7 +153,7 @@ def test_crt(mock_ubipopulate):
     main(args)
     mock_ubipopulate.assert_called_once_with(
         "foo.pulp.com",
-        ("/cert.cert",),
+        ("/cert.cert", "/cert.key"),
         False,
         [],
         "custom/conf/dir",

--- a/tests/test_pulp.py
+++ b/tests/test_pulp.py
@@ -30,7 +30,7 @@ ORIG_HTTP_RETRY_BACKOFF = pulp_client.HTTP_RETRY_BACKOFF
 
 @pytest.fixture(name="mock_pulp")
 def fixture_mock_pulp():
-    yield Pulp("foo.pulp.com", (None,))
+    yield Pulp("foo.pulp.com")
 
 
 @pytest.fixture(name="mock_repo")
@@ -379,5 +379,9 @@ def test_session_is_not_shared(mock_pulp, count):
 
 def test_insecure():
     with patch("urllib3.disable_warnings") as patched_warnings:
-        Pulp("foo.host", ("fake", "user"), insecure=True)
+        kwargs = {
+            "auth": ("fake", "user"),
+            "insecure": True,
+        }
+        Pulp("foo.host", **kwargs)
         patched_warnings.assert_called_once()

--- a/ubipop/_pulp_client.py
+++ b/ubipop/_pulp_client.py
@@ -45,17 +45,29 @@ class PulpRetryAdapter(requests.adapters.HTTPAdapter):
 class Pulp(object):
     PULP_API = "/pulp/api/v2/"
 
-    def __init__(self, hostname, auth, insecure=False):
+    def __init__(self, hostname, **kwargs):
         self.hostname = hostname
-        self.auth = auth
         self.scheme = "https://"
         self.base_url = urljoin(self.scheme + hostname, self.PULP_API)
-        self.insecure = insecure
         self.local = threading.local()
-        if insecure:
+
+        self._session_kwargs = {}
+
+        if "insecure" in kwargs:
+            kwargs["verify"] = not kwargs.pop("insecure")
+
+        if not kwargs.get("verify"):
             import urllib3
 
             urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+
+        for arg in (
+            "auth",
+            "cert",
+            "verify",
+        ):
+            if arg in kwargs:
+                self._session_kwargs[arg] = kwargs.pop(arg)
 
     def _make_session(self):
         adapter = PulpRetryAdapter()
@@ -63,10 +75,8 @@ class Pulp(object):
         session.mount("http://", adapter)
         session.mount("https://", adapter)
 
-        if len(self.auth) == 1:
-            session.cert = self.auth[0]
-        else:
-            session.auth = self.auth
+        for key, value in self._session_kwargs.items():
+            setattr(session, key, value)
 
         self.local.session = session
 
@@ -77,13 +87,9 @@ class Pulp(object):
         req_url = urljoin(self.base_url, url)
 
         if req_type == "post":
-            ret = self.local.session.post(
-                req_url, json=data, verify=not self.insecure, timeout=HTTP_TIMEOUT
-            )
+            ret = self.local.session.post(req_url, json=data, timeout=HTTP_TIMEOUT)
         elif req_type == "get":
-            ret = self.local.session.get(
-                req_url, verify=not self.insecure, timeout=HTTP_TIMEOUT
-            )
+            ret = self.local.session.get(req_url, timeout=HTTP_TIMEOUT)
         else:
             ret = None
 

--- a/ubipop/cli.py
+++ b/ubipop/cli.py
@@ -58,7 +58,16 @@ def parse_args(args):
         "--password", action="store", required=False, help="pulp password"
     )
     parser.add_argument(
-        "--cert", action="store", required=False, help="path to to user cert"
+        "--cert",
+        action="store",
+        required=False,
+        help="path to to user cert for pulp authentication",
+    )
+    parser.add_argument(
+        "--key",
+        action="store",
+        required=False,
+        help="path to to user key for pulp authentication",
     )
     parser.add_argument(
         "--workers",
@@ -95,18 +104,17 @@ def parse_args(args):
 
     parsed = parser.parse_args(args)
 
-    auth_err_msg = "Provide --user and --password options or --cert"
-    if all((parsed.user, parsed.password, parsed.cert)):
+    auth_err_msg = "Provide --user and --password options or --cert and --key"
+    if all((parsed.user, parsed.password, parsed.cert, parsed.key)):
         parser.error(auth_err_msg)
 
-    auth = None
+    auth = (None, None)
     if parsed.user and parsed.password:
         auth = (parsed.user, parsed.password)
-    elif parsed.user and not parsed.password or not parsed.user and parsed.password:
-        parser.error(auth_err_msg)
-    elif parsed.cert:
-        auth = (parsed.cert,)
-    else:
+    elif parsed.cert and parsed.key:
+        auth = (parsed.cert, parsed.key)
+
+    if not all(auth):
         parser.error(auth_err_msg)
 
     return parser.parse_args(args), auth


### PR DESCRIPTION
Adding support for PKI auth to pulp.
* Ubipop is now able to communicate with pulp also by using cert/key.
* Cert/key is possible to pass via CLI