### PR TITLE
Fix TTL extraction [RHELDST-20510]

### DIFF
--- a/tests/test_cdn.py
+++ b/tests/test_cdn.py
@@ -111,8 +111,12 @@ def test_publisher_with_cache_purge(pulp, requests_mock):
     setup_fastpurge_mock(requests_mock)
 
     url_ttl = ("https://cdn.example.com/content/unit/1/client/repomd.xml", "33s")
-
-    headers = {"X-Cache-Key": f"/fake/cache-key/{url_ttl[1]}/something"}
+    # ARLs are generated from the template using the {ttl} placeholder, which is replaced with
+    # the real TTL value. The real TTL value is extracted from the cache key header of the real
+    # request for the given path using '/(\d+[smhd])/' regex.
+    # The /1h/foo in the mocked header here is to test that if the path contains a component
+    # that also matches the TTL regex ('/1h/'), it will still find the correct value ('/33s/').
+    headers = {"X-Cache-Key": f"/fake/cache-key/{url_ttl[1]}/something/1h/foo"}
     requests_mock.register_uri("HEAD", url_ttl[0], headers=headers)
 
     # enqueue repos to publish and wait for publish and purge to finish

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ envlist = py38,py39,static,docs,integration
 deps=-rtest-requirements.txt
 commands=
         pytest -v {posargs}
-whitelist_externals=sh
+allowlist_externals=sh
 
 [testenv:integration]
 passenv =
@@ -16,7 +16,7 @@ passenv =
 deps=-rtest-requirements.txt
 commands=
         pytest -v {posargs} tests/integration
-whitelist_externals=yum
+allowlist_externals=yum
 
 [testenv:static]
 deps=
@@ -28,6 +28,7 @@ commands=
 	black --check .
 	sh -c 'pylint -f colorized ubipop tests; test $(( $? & (1|2|4|32) )) = 0'
 allowlist_externals=sh
+
 [testenv:cov]
 deps=
 	-rtest-requirements.txt

--- a/ubipop/_cdn.py
+++ b/ubipop/_cdn.py
@@ -161,7 +161,7 @@ class CdnClient:
     _EXPONENT = float(os.environ.get("CDN_RETRY_EXPONENT", "3.0"))
     _MAX_SLEEP = float(os.environ.get("CDN_RETRY_MAX_SLEEP", "120.0"))
 
-    TTL_REGEX = re.compile(r".*/(\d+[smhd])/.*")
+    TTL_REGEX = re.compile(r"/(\d+[smhd])/")
     CACHE_KEY_HEADER = HeaderPair("akamai-x-get-cache-key", "X-Cache-Key")
 
     def __init__(self, url, arl_templates=None, max_retry_sleep=_MAX_SLEEP, **kwargs):
@@ -242,7 +242,7 @@ class CdnClient:
         out = self._get_headers_for_path(path, headers)
 
         def _parse_ttl(value):
-            parsed = re.match(
+            parsed = re.search(
                 self.TTL_REGEX, value.get(self.CACHE_KEY_HEADER.response) or ""
             )
             return parsed.group(1) if parsed else None


### PR DESCRIPTION
Previously the TTL extraction was implemented in such way that it could potentially extract the wrong value, if the URL path contained a component that also matched the regex.
This commit changes the re.match() to re.search(), which ensures it will find the first occurrence of the match.
It also changes whitelist_externals to allowlist_externals in tox.ini