### PR TITLE
Fix setting verify for requests

### DIFF
--- a/ubipop/_cdn.py
+++ b/ubipop/_cdn.py
@@ -216,6 +216,10 @@ class CdnClient:
         return self._tls.session
 
     def _head(self, *args, **kwargs):
+        # set verify for each request
+        # verify set on session doesn't work due to https://github.com/psf/requests/issues/3829
+        # if REQUESTS_CA_BUNDLE is set on env, it takes precedence
+        kwargs["verify"] = self._session.verify
         return self._session.head(*args, **kwargs)
 
     def _on_failure(self, header, exception):


### PR DESCRIPTION
Due to bug https://github.com/psf/requests/issues/3829, setting 'verify' on session doesn't work if REQUESTS_CA_BUNDLE is set on environment. The bundle defined via REQUESTS_CA_BUNDLE will take precedence and the custom bundle provided via 'verify' is ignored.

Let's now set 'verify' for each request.

This can be revetrted when the bug is fixed, likely in python-requests-v3.