### PR TITLE
Update the assert message for module list

### DIFF
--- a/tests/integration/test_association.py
+++ b/tests/integration/test_association.py
@@ -630,7 +630,7 @@ def test_ubipop_not_filter_module_rpm_with_different_version(pulp_client):
         mod_name == "container-tools"
     ), "Expected modulemd: container-tools, found modulemd: {}".format(mod_name)
     assert (
-        "common [d]" in mod_profile
+        "common" in mod_profile
     ), "Modulemd container-tools should have common profile as default."
 
 


### PR DESCRIPTION
1.update the assert message for module test case

to fix the integration test fail
https://master-jenkins-csb-distribution.apps.ocp-c1.prod.psi.redhat.com/view/ubipop/job/ubipop-pulp-integration/235/