### PR TITLE
Remove urllib<2 requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,3 @@ pyrsistent
 pubtools-pulplib>=2.34.2
 attrs
 fastpurge
-urllib3<2


### PR DESCRIPTION
With recent changes:
* 8455d0ccdd87a7040b9b1d8dd063d59617216ae9 it is not required to use urllib<2.