### PR TITLE
Set mutual_auth as optional [RHELDST-24814]

### DIFF
--- a/tests/test_ubi_manifest_client.py
+++ b/tests/test_ubi_manifest_client.py
@@ -203,7 +203,7 @@ def test_kerberos_auth(kerb_mock, requests_mock):
         with Client("https://foo-bar.com") as client:
             _ = client._do_request(method="GET", url=url)
             kerb_mock.assert_called_once_with(
-                mutual_authentication=1,
+                mutual_authentication=2,
                 force_preemptive=True,
                 principal="principal@REALM.COM",
             )

--- a/ubipop/ubi_manifest_client/client.py
+++ b/ubipop/ubi_manifest_client/client.py
@@ -2,7 +2,7 @@ import logging
 import os
 import threading
 from concurrent.futures import as_completed
-from requests_kerberos import HTTPKerberosAuth, REQUIRED
+from requests_kerberos import HTTPKerberosAuth, OPTIONAL
 
 import requests
 from more_executors import Executors, f_map, f_proxy
@@ -69,7 +69,7 @@ class Client:
                         "Please set 'UBIPOP_KERBEROS_PRINCIPAL_UBI_MANIFEST' environment variable"
                     )
                 self._tls.session.auth = HTTPKerberosAuth(
-                    mutual_authentication=REQUIRED,
+                    mutual_authentication=OPTIONAL,
                     force_preemptive=True,
                     principal=self.krb_principal,
                 )


### PR DESCRIPTION
The mutual_auth for kerberos was set as REQUIRED, but this was too demanding on auth. servers. Let's ease that a bit and set that as OPTIONAL.