### PR TITLE
Fix the failture of ubipop for rhel7

### DIFF
--- a/tests/integration/test_association.py
+++ b/tests/integration/test_association.py
@@ -427,14 +427,18 @@ def test_run_ubi_pop_for_rhel7(pulp_client):
         ), "Can't find the modulemd_default :{}".format(modulemd_defaults)
 
     # verify the modulemd exist and modulemd default in the cdn server
-    modulemds = query_repo_modules(None, "ubi", rpm_repo_url, full_data=True)
+    modulemds = query_repo_modules(None, "ubi", rpm_repo_url)
+    while "" in modulemds:
+        modulemds.remove("")
     assert len(modulemds) == 3, "Unexpected repo modulemds found."
+    # assert the module prefile
+    modulemds = query_repo_modules(None, "ubi", rpm_repo_url, full_data=True)
     mod_name, mod_profile = separate_modules(modulemds)[0]
     assert mod_name == "httpd", "Expected modulemd: httpd, found modulemd: {}".format(
         mod_name
     )
     assert (
-        "common [d]" in mod_profile
+        "common" in mod_profile
     ), "Modulemd httpd should have common profile as default."
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -15,6 +15,8 @@ passenv =
 	REQUESTS_CA_BUNDLE
 	TEST_MANIFEST_URL
 	GITLAB_CONFIG_URL
+	UBIPOP_SKIP_PUBLISH
+	PUB_CONFIG_FILE
 allowlist_externals = yum
 commands =
 	pytest -v {posargs} tests/integration


### PR DESCRIPTION
After the slave update from fedora 38 to fedora 40, the module query list return empty string, so remove the empty string and make the test case is pass.