### PR TITLE
Fix usage of tox and poetry in ubi-population-tool [RHELDST-32220]

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -3,9 +3,9 @@ envlist = py39, py312, py313, static, docs, integration
 
 [testenv]
 commands = pytest -v {posargs}
+allowlist_externals = sh, poetry
 skip_install = true
-commands_pre = 
-	pip install poetry
+commands_pre =
 	poetry run pip -V
 	poetry install --with dev,test
 
@@ -16,12 +16,11 @@ passenv =
 	TEST_MANIFEST_URL
 	GITLAB_CONFIG_URL
 	PUB_CONFIG_FILE
-allowlist_externals = yum
+allowlist_externals = yum, poetry
 commands =
 	pytest -v {posargs} tests/integration
 
 [testenv:static]
-allowlist_externals = sh
 commands =
 	black --check .
 	sh -c 'pylint -f colorized ubipop tests; test $(( $? & (1|2|4|32) )) = 0'
@@ -33,7 +32,6 @@ commands =
 
 [testenv:docs]
 use_develop = true
-allowlist_externals = sphinx-build
 commands  =
 	poetry install --with docs
 	sphinx-build -M html docs docs/_build


### PR DESCRIPTION
Install poetry in system-wide with pip or pipx.